### PR TITLE
PR/ Auth configuration and Notification system

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -40,6 +40,68 @@
     "success": "If that account exists, your administrator has been notified.",
     "invalidEmail": "Enter a valid email address."
   },
+  "ChangePassword": {
+    "title": "Set a new password",
+    "subtitle": "You must change your temporary password before continuing.",
+    "currentPassword": "Current password",
+    "newPassword": "New password",
+    "confirmPassword": "Confirm password",
+    "hint": "At least 8 characters, including a letter and a number.",
+    "show": "Show password",
+    "hide": "Hide password",
+    "strengthWeak": "Weak",
+    "strengthFair": "Fair",
+    "strengthStrong": "Strong",
+    "submit": "Update password",
+    "submitting": "Updating…",
+    "success": "Password updated.",
+    "error": "Could not update your password."
+  },
+  "Accounts": {
+    "title": "User accounts",
+    "subtitle": "Create accounts and assign a role. Accounts are created here only — there is no public sign-up.",
+    "createHeading": "Create account",
+    "listHeading": "Accounts",
+    "fullName": "Full name",
+    "email": "Email",
+    "role": "Role",
+    "tempPassword": "Temporary password",
+    "generate": "Generate a new password",
+    "createBtn": "Create account",
+    "creating": "Creating…",
+    "createdTitle": "Account created",
+    "createdBody": "Share these credentials with the user securely. They must change the password on first login.",
+    "copy": "Copy",
+    "copied": "Copied.",
+    "done": "Done",
+    "status": "Status",
+    "active": "Active",
+    "inactive": "Inactive",
+    "mustChange": "Must change password",
+    "forbidden": "Only a Super Admin can create accounts.",
+    "unauthorized": "You are not signed in.",
+    "createFailed": "Could not create the account.",
+    "actions": "Actions",
+    "resetPassword": "Reset password",
+    "resetFailed": "Could not reset the password.",
+    "resetDoneTitle": "Temporary password set",
+    "resetDoneBody": "Share this with {name} securely. They must change it at next login."
+  },
+  "Notifications": {
+    "title": "Notifications",
+    "empty": "No notifications.",
+    "seeAll": "See all notifications",
+    "allTitle": "All notifications",
+    "clearAll": "Clear all",
+    "delete": "Delete",
+    "markAllRead": "Mark all as read",
+    "close": "Close",
+    "generic": "Notification",
+    "passwordResetRequest": {
+      "title": "Password reset requested",
+      "body": "{email} needs a new password. Open Accounts to set a temporary one."
+    }
+  },
   "Profile": {
     "title": "My profile",
     "subtitle": "Your account details.",
@@ -62,7 +124,8 @@
     "nameRequired": "Name is required.",
     "imageTooLarge": "That image is too large.",
     "updateError": "Could not update your profile.",
-    "notAnImage": "Please choose an image file."
+    "notAnImage": "Please choose an image file.",
+    "changePassword": "Change my password"
   },
   "Dashboard": {
     "title": "Dashboard",
@@ -222,6 +285,14 @@
     "minItems": "Add at least one item.",
     "positive": "Enter a number greater than zero.",
     "nonNegative": "Enter zero or more.",
-    "discountTooLarge": "Discount cannot exceed the subtotal."
+    "discountTooLarge": "Discount cannot exceed the subtotal.",
+    "passwordShort": "Use at least 8 characters.",
+    "passwordLetter": "Include at least one letter.",
+    "passwordNumber": "Include at least one number.",
+    "passwordMismatch": "Passwords do not match.",
+    "passwordSame": "The new password must be different from the current one.",
+    "incorrectPassword": "The current password is incorrect.",
+    "invalidEmail": "Enter a valid email address.",
+    "emailInUse": "An account with this email already exists."
   }
 }

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -40,6 +40,68 @@
     "success": "Si ce compte existe, votre administrateur a \u00e9t\u00e9 notifi\u00e9.",
     "invalidEmail": "Saisissez une adresse e-mail valide."
   },
+  "ChangePassword": {
+    "title": "D\u00e9finir un nouveau mot de passe",
+    "subtitle": "Vous devez changer votre mot de passe temporaire avant de continuer.",
+    "currentPassword": "Mot de passe actuel",
+    "newPassword": "Nouveau mot de passe",
+    "confirmPassword": "Confirmer le mot de passe",
+    "hint": "Au moins 8 caract\u00e8res, dont une lettre et un chiffre.",
+    "show": "Afficher le mot de passe",
+    "hide": "Masquer le mot de passe",
+    "strengthWeak": "Faible",
+    "strengthFair": "Moyen",
+    "strengthStrong": "Fort",
+    "submit": "Mettre \u00e0 jour le mot de passe",
+    "submitting": "Mise \u00e0 jour\u2026",
+    "success": "Mot de passe mis \u00e0 jour.",
+    "error": "Impossible de mettre \u00e0 jour votre mot de passe."
+  },
+  "Accounts": {
+    "title": "Comptes utilisateurs",
+    "subtitle": "Cr\u00e9ez des comptes et attribuez un r\u00f4le. Les comptes sont cr\u00e9\u00e9s uniquement ici \u2014 aucune inscription publique.",
+    "createHeading": "Cr\u00e9er un compte",
+    "listHeading": "Comptes",
+    "fullName": "Nom complet",
+    "email": "Adresse e-mail",
+    "role": "R\u00f4le",
+    "tempPassword": "Mot de passe temporaire",
+    "generate": "G\u00e9n\u00e9rer un nouveau mot de passe",
+    "createBtn": "Cr\u00e9er le compte",
+    "creating": "Cr\u00e9ation\u2026",
+    "createdTitle": "Compte cr\u00e9\u00e9",
+    "createdBody": "Partagez ces identifiants avec l'utilisateur de fa\u00e7on s\u00e9curis\u00e9e. Il devra changer le mot de passe \u00e0 la premi\u00e8re connexion.",
+    "copy": "Copier",
+    "copied": "Copi\u00e9.",
+    "done": "Termin\u00e9",
+    "status": "Statut",
+    "active": "Actif",
+    "inactive": "Inactif",
+    "mustChange": "Doit changer le mot de passe",
+    "forbidden": "Seul un Super Admin peut cr\u00e9er des comptes.",
+    "unauthorized": "Vous n'\u00eates pas connect\u00e9.",
+    "createFailed": "Impossible de cr\u00e9er le compte.",
+    "actions": "Actions",
+    "resetPassword": "R\u00e9initialiser le mot de passe",
+    "resetFailed": "Impossible de r\u00e9initialiser le mot de passe.",
+    "resetDoneTitle": "Mot de passe temporaire d\u00e9fini",
+    "resetDoneBody": "Partagez-le avec {name} de fa\u00e7on s\u00e9curis\u00e9e. Il devra le changer \u00e0 la prochaine connexion."
+  },
+  "Notifications": {
+    "title": "Notifications",
+    "empty": "Aucune notification.",
+    "seeAll": "Voir toutes les notifications",
+    "allTitle": "Toutes les notifications",
+    "clearAll": "Tout effacer",
+    "delete": "Supprimer",
+    "markAllRead": "Tout marquer comme lu",
+    "close": "Fermer",
+    "generic": "Notification",
+    "passwordResetRequest": {
+      "title": "R\u00e9initialisation de mot de passe demand\u00e9e",
+      "body": "{email} a besoin d'un nouveau mot de passe. Ouvrez Comptes pour en d\u00e9finir un temporaire."
+    }
+  },
   "Profile": {
     "title": "Mon profil",
     "subtitle": "Les informations de votre compte.",
@@ -62,7 +124,8 @@
     "nameRequired": "Le nom est obligatoire.",
     "imageTooLarge": "Cette image est trop volumineuse.",
     "updateError": "Impossible de mettre \u00e0 jour votre profil.",
-    "notAnImage": "Veuillez choisir un fichier image."
+    "notAnImage": "Veuillez choisir un fichier image.",
+    "changePassword": "Changer mon mot de passe"
   },
   "Dashboard": {
     "title": "Tableau de bord",
@@ -222,6 +285,14 @@
     "minItems": "Ajoutez au moins un article.",
     "positive": "Saisissez un nombre sup\u00e9rieur \u00e0 z\u00e9ro.",
     "nonNegative": "Saisissez z\u00e9ro ou plus.",
-    "discountTooLarge": "La remise ne peut d\u00e9passer le sous-total."
+    "discountTooLarge": "La remise ne peut d\u00e9passer le sous-total.",
+    "passwordShort": "Utilisez au moins 8 caract\u00e8res.",
+    "passwordLetter": "Incluez au moins une lettre.",
+    "passwordNumber": "Incluez au moins un chiffre.",
+    "passwordMismatch": "Les mots de passe ne correspondent pas.",
+    "passwordSame": "Le nouveau mot de passe doit \u00eatre diff\u00e9rent de l'actuel.",
+    "incorrectPassword": "Le mot de passe actuel est incorrect.",
+    "invalidEmail": "Saisissez une adresse e-mail valide.",
+    "emailInUse": "Un compte avec cet e-mail existe d\u00e9j\u00e0."
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "db:reset": "supabase db reset",
     "db:policies": "node scripts/apply-policies.mjs",
     "db:seed:users": "node scripts/seed-users.mjs",
+    "db:reset:passwords": "node scripts/reset-all-passwords.mjs",
     "db:types": "supabase gen types typescript --linked --schema public > src/types/database.types.ts"
   },
   "dependencies": {

--- a/scripts/reset-all-passwords.mjs
+++ b/scripts/reset-all-passwords.mjs
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+/**
+ * Resets EVERY existing account's password to the shared temporary password and
+ * flags must_change_password, so each user is forced to set their own on next
+ * login. One-off admin operation -- run deliberately.
+ *
+ * Uses the service-role key (bypasses RLS); never ship it to the browser.
+ *
+ * Environment (read from .env.local if present):
+ *   NEXT_PUBLIC_SUPABASE_URL      project URL          (required)
+ *   SUPABASE_SERVICE_ROLE_KEY     service-role secret  (required)
+ *   SEED_DEFAULT_PASSWORD         temp password        (default below)
+ *
+ * Usage:  npm run db:reset:passwords
+ */
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { createClient } from '@supabase/supabase-js';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+loadEnvFile(join(root, '.env.local'));
+
+const DEFAULT_PASSWORD = 'Uniforme2026!';
+const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+const password = process.env.SEED_DEFAULT_PASSWORD || DEFAULT_PASSWORD;
+
+if (!url || !serviceKey) {
+  console.error(
+    'Missing NEXT_PUBLIC_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY.\n' +
+      'Set them in .env.local (Supabase -> Project Settings -> API) and re-run.'
+  );
+  process.exit(1);
+}
+
+const admin = createClient(url, serviceKey, {
+  auth: { autoRefreshToken: false, persistSession: false }
+});
+
+const users = await listAllUsers();
+let done = 0;
+for (const u of users) {
+  const { error } = await admin.auth.admin.updateUserById(u.id, {
+    password,
+    user_metadata: { ...u.user_metadata, must_change_password: true }
+  });
+  if (error) {
+    console.error(`  fail   ${u.email}: ${error.message}`);
+    continue;
+  }
+  done++;
+  console.log(`  reset  ${u.email}`);
+}
+
+console.log(
+  `\nReset ${done}/${users.length} account(s) to "${password}".` +
+    '\nEach user must change it on next login (must_change_password=true).\n'
+);
+
+// --- helpers ---------------------------------------------------------------
+
+async function listAllUsers() {
+  const all = [];
+  const perPage = 1000;
+  for (let page = 1; ; page++) {
+    const { data, error } = await admin.auth.admin.listUsers({ page, perPage });
+    if (error) throw new Error(`listUsers: ${error.message}`);
+    all.push(...data.users);
+    if (data.users.length < perPage) break;
+  }
+  return all;
+}
+
+function loadEnvFile(path) {
+  let text;
+  try {
+    text = readFileSync(path, 'utf8');
+  } catch {
+    return;
+  }
+  for (const line of text.split(/\r?\n/)) {
+    const m = line.match(/^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*?)\s*$/);
+    if (!m) continue;
+    const [, key] = m;
+    let val = m[2];
+    if (
+      (val.startsWith('"') && val.endsWith('"')) ||
+      (val.startsWith("'") && val.endsWith("'"))
+    ) {
+      val = val.slice(1, -1);
+    }
+    if (process.env[key] === undefined) process.env[key] = val;
+  }
+}

--- a/src/actions/accounts.ts
+++ b/src/actions/accounts.ts
@@ -1,0 +1,128 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+import { createClient } from '@/lib/supabase/server';
+import { createAdminClient } from '@/lib/supabase/admin';
+import { createAccountSchema, type CreateAccountInput } from '@/lib/validation/auth-schema';
+
+export type CreateAccountResult =
+  | { ok: true; email: string }
+  | {
+      ok: false;
+      error?: string;
+      fieldErrors?: Partial<Record<'full_name' | 'email' | 'role' | 'password', string>>;
+    };
+
+/**
+ * Creates a user account with a role and a temporary password (spec A-FR-3.1:
+ * accounts are created by the Super Admin only). Enforced server-side — the
+ * caller's role is checked here, not just hidden in the UI — so a direct call by
+ * a non-super-admin is refused. The new account is flagged must_change_password.
+ */
+export async function createAccount(
+  input: CreateAccountInput
+): Promise<CreateAccountResult> {
+  const parsed = createAccountSchema.safeParse(input);
+  if (!parsed.success) {
+    const fieldErrors: Partial<
+      Record<'full_name' | 'email' | 'role' | 'password', string>
+    > = {};
+    for (const issue of parsed.error.issues) {
+      const field = issue.path[0];
+      if (field === 'full_name' || field === 'email' || field === 'role' || field === 'password') {
+        fieldErrors[field] ??= issue.message;
+      }
+    }
+    return { ok: false, fieldErrors };
+  }
+
+  // Authorisation: the caller must be a Super Admin. Checked on the server.
+  const supabase = await createClient();
+  const {
+    data: { user }
+  } = await supabase.auth.getUser();
+  if (!user) return { ok: false, error: 'unauthorized' };
+
+  const { data: me } = await supabase
+    .from('profiles')
+    .select('role')
+    .eq('id', user.id)
+    .single();
+  if (me?.role !== 'super_admin') return { ok: false, error: 'forbidden' };
+
+  const { full_name, email, role, password } = parsed.data;
+  const admin = createAdminClient();
+
+  const { data: created, error } = await admin.auth.admin.createUser({
+    email,
+    password,
+    email_confirm: true, // no public email flow -- confirm immediately (A-FR-3.1)
+    user_metadata: { full_name, must_change_password: true }, // forced change (A-FR-3.2)
+    app_metadata: { role }
+  });
+  if (error || !created?.user) {
+    return { ok: false, error: error?.message ?? 'createFailed' };
+  }
+
+  // profiles.role is the source of truth RLS reads; app_metadata is a convenience copy.
+  const { error: pErr } = await admin
+    .from('profiles')
+    .upsert({ id: created.user.id, full_name, role, is_active: true }, { onConflict: 'id' });
+  if (pErr) return { ok: false, error: pErr.message };
+
+  revalidatePath('/', 'layout');
+  return { ok: true, email };
+}
+
+function genTempPassword() {
+  const letters = 'abcdefghjkmnpqrstuvwxyz';
+  const pick = (n: number) =>
+    Array.from({ length: n }, () => letters[Math.floor(Math.random() * letters.length)]).join('');
+  return `Frst-${pick(4)}${Math.floor(1000 + Math.random() * 9000)}`;
+}
+
+export type ResetPasswordResult =
+  | { ok: true; password: string }
+  | { ok: false; error: string };
+
+/**
+ * Sets a fresh temporary password for any user (including the Super Admin's own
+ * account) and re-flags must_change_password, so the user must change it after
+ * logging in with it. Super-Admin-only, enforced server-side. Returns the temp
+ * password so it can be shared securely.
+ */
+export async function resetUserPassword(userId: string): Promise<ResetPasswordResult> {
+  const supabase = await createClient();
+  const {
+    data: { user }
+  } = await supabase.auth.getUser();
+  if (!user) return { ok: false, error: 'unauthorized' };
+
+  const { data: me } = await supabase
+    .from('profiles')
+    .select('role')
+    .eq('id', user.id)
+    .single();
+  if (me?.role !== 'super_admin') return { ok: false, error: 'forbidden' };
+
+  const admin = createAdminClient();
+  const { data: target } = await admin.auth.admin.getUserById(userId);
+  const meta = (target?.user?.user_metadata ?? {}) as Record<string, unknown>;
+
+  const password = genTempPassword();
+  const { error } = await admin.auth.admin.updateUserById(userId, {
+    password,
+    user_metadata: { ...meta, must_change_password: true }
+  });
+  if (error) return { ok: false, error: error.message };
+
+  // Resolve any pending reset-request notifications that pointed at this user.
+  await admin
+    .from('notifications')
+    .update({ is_read: true })
+    .eq('type', 'password_reset_request')
+    .contains('data', { targetUserId: userId });
+
+  revalidatePath('/', 'layout');
+  return { ok: true, password };
+}

--- a/src/actions/auth.ts
+++ b/src/actions/auth.ts
@@ -1,10 +1,15 @@
 'use server';
 
+import { cache } from 'react';
 import { revalidatePath } from 'next/cache';
 import { getLocale } from 'next-intl/server';
+import { createClient as createSupabaseJsClient } from '@supabase/supabase-js';
 import { redirect } from '@/i18n/navigation';
 import { createClient } from '@/lib/supabase/server';
+import { createAdminClient } from '@/lib/supabase/admin';
+import { requireSupabaseEnv } from '@/lib/supabase/env';
 import {
+  changePasswordSchema,
   emptyLoginState,
   loginSchema,
   type LoginState
@@ -55,6 +60,102 @@ export async function signIn(
   return emptyLoginState;
 }
 
+/**
+ * A signed-out user asks for a password reset. Per A-FR-3.5 there is no
+ * self-service email reset: instead every active Super Admin is notified in-app
+ * and issues a temporary password. Always resolves the same way regardless of
+ * whether the address exists, so the form can't be used to enumerate accounts.
+ */
+export async function requestPasswordReset(email: string): Promise<{ ok: true }> {
+  const clean = email.trim().toLowerCase();
+  if (clean.includes('@')) {
+    try {
+      const admin = createAdminClient();
+      const { data: list } = await admin.auth.admin.listUsers({ page: 1, perPage: 1000 });
+      const target = list?.users.find((u) => u.email?.toLowerCase() === clean);
+      if (target) {
+        const { data: admins } = await admin
+          .from('profiles')
+          .select('id')
+          .eq('role', 'super_admin')
+          .eq('is_active', true);
+        const ids = (admins ?? []).map((a) => a.id);
+        if (ids.length > 0) {
+          await admin.from('notifications').insert(
+            ids.map((user_id) => ({
+              user_id,
+              type: 'password_reset_request',
+              link: '/accounts',
+              data: { email: clean, targetUserId: target.id }
+            }))
+          );
+        }
+      }
+    } catch {
+      // Never surface an error to the requester.
+    }
+  }
+  return { ok: true };
+}
+
+export type ChangePasswordResult =
+  | { ok: true }
+  | {
+      ok: false;
+      error?: string;
+      fieldErrors?: { current?: string; password?: string; confirm?: string };
+    };
+
+/**
+ * Sets a new password for the signed-in user and clears the forced-change flag
+ * (must_change_password). The current password must be supplied and is verified
+ * first. Everything is re-checked on the server, not trusted from the client.
+ */
+export async function changePassword(input: {
+  current: string;
+  password: string;
+  confirm: string;
+}): Promise<ChangePasswordResult> {
+  const parsed = changePasswordSchema.safeParse(input);
+  if (!parsed.success) {
+    const fieldErrors: { current?: string; password?: string; confirm?: string } = {};
+    for (const issue of parsed.error.issues) {
+      const field = issue.path[0];
+      if (field === 'current' || field === 'password' || field === 'confirm') {
+        fieldErrors[field] ??= issue.message;
+      }
+    }
+    return { ok: false, fieldErrors };
+  }
+
+  const supabase = await createClient();
+  const {
+    data: { user }
+  } = await supabase.auth.getUser();
+  if (!user?.email) return { ok: false, error: 'unauthorized' };
+
+  // Verify the current password with a throwaway client so we don't disturb the
+  // live session cookies. A failed sign-in means the current password is wrong.
+  const { url, anonKey } = requireSupabaseEnv();
+  const verifier = createSupabaseJsClient(url, anonKey, {
+    auth: { autoRefreshToken: false, persistSession: false }
+  });
+  const { error: verifyErr } = await verifier.auth.signInWithPassword({
+    email: user.email,
+    password: parsed.data.current
+  });
+  if (verifyErr) return { ok: false, fieldErrors: { current: 'incorrectPassword' } };
+
+  const { error } = await supabase.auth.updateUser({
+    password: parsed.data.password,
+    data: { ...user.user_metadata, must_change_password: false }
+  });
+  if (error) return { ok: false, error: error.message };
+
+  revalidatePath('/', 'layout');
+  return { ok: true };
+}
+
 export async function signOut(): Promise<void> {
   const supabase = await createClient();
   await supabase.auth.signOut();
@@ -64,8 +165,9 @@ export async function signOut(): Promise<void> {
   redirect({ href: '/login', locale });
 }
 
-/** The signed-in user's profile, or null. Used by the dashboard shell. */
-export async function getProfile() {
+// Memoised per request: the layout, the page and any actions in the same render
+// share a single auth + profile round-trip instead of repeating it each time.
+const loadProfile = cache(async () => {
   const supabase = await createClient();
   const {
     data: { user }
@@ -80,6 +182,11 @@ export async function getProfile() {
 
   if (!data) return null;
   return { ...data, email: user.email ?? '' };
+});
+
+/** The signed-in user's profile, or null. Used by the dashboard shell. */
+export async function getProfile() {
+  return loadProfile();
 }
 
 export type UpdateProfileResult = { ok: true } | { ok: false; error: string };

--- a/src/actions/notifications.ts
+++ b/src/actions/notifications.ts
@@ -1,0 +1,54 @@
+'use server';
+
+import { createClient } from '@/lib/supabase/server';
+
+export type AppNotification = {
+  id: string;
+  type: string;
+  data: Record<string, unknown>;
+  link: string | null;
+  is_read: boolean;
+  created_at: string;
+};
+
+/** The signed-in user's notifications, newest first. */
+export async function listNotifications(): Promise<AppNotification[]> {
+  const supabase = await createClient();
+  const { data } = await supabase
+    .from('notifications')
+    .select('id, type, data, link, is_read, created_at')
+    .order('created_at', { ascending: false })
+    .limit(60);
+  return (data ?? []).map((n) => ({
+    ...n,
+    data: (n.data as Record<string, unknown>) ?? {}
+  }));
+}
+
+export async function markNotificationRead(id: string) {
+  const supabase = await createClient();
+  await supabase.from('notifications').update({ is_read: true }).eq('id', id);
+  return { ok: true as const };
+}
+
+export async function markAllNotificationsRead() {
+  const supabase = await createClient();
+  await supabase.from('notifications').update({ is_read: true }).eq('is_read', false);
+  return { ok: true as const };
+}
+
+export async function deleteNotification(id: string) {
+  const supabase = await createClient();
+  await supabase.from('notifications').delete().eq('id', id);
+  return { ok: true as const };
+}
+
+export async function clearNotifications() {
+  const supabase = await createClient();
+  const {
+    data: { user }
+  } = await supabase.auth.getUser();
+  if (!user) return { ok: false as const };
+  await supabase.from('notifications').delete().eq('user_id', user.id);
+  return { ok: true as const };
+}

--- a/src/app/[locale]/(dashboard)/accounts/page.tsx
+++ b/src/app/[locale]/(dashboard)/accounts/page.tsx
@@ -1,0 +1,130 @@
+import { notFound } from 'next/navigation';
+import { getTranslations, setRequestLocale } from 'next-intl/server';
+import { getProfile } from '@/actions/auth';
+import { createAdminClient } from '@/lib/supabase/admin';
+import { CreateAccountForm } from '@/components/forms/create-account-form';
+import { ResetPasswordButton } from '@/components/forms/reset-password-button';
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow
+} from '@/components/ui/table';
+import type { UserRole } from '@/types/database.types';
+
+type Props = { params: Promise<{ locale: string }> };
+
+export async function generateMetadata({ params }: Props) {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: 'Accounts' });
+  return { title: t('title') };
+}
+
+export default async function AccountsPage({ params }: Props) {
+  const { locale } = await params;
+  setRequestLocale(locale);
+
+  const [profile, t, tRoles] = await Promise.all([
+    getProfile(),
+    getTranslations('Accounts'),
+    getTranslations('Dashboard')
+  ]);
+
+  // Server-side authorisation: only the Super Admin manages accounts.
+  if (!profile || profile.role !== 'super_admin') notFound();
+
+  const admin = createAdminClient();
+  const [{ data: userData }, { data: profs }] = await Promise.all([
+    admin.auth.admin.listUsers({ page: 1, perPage: 1000 }),
+    admin.from('profiles').select('id, full_name, role, is_active')
+  ]);
+
+  const byId = new Map((profs ?? []).map((p) => [p.id, p]));
+  const rows = (userData?.users ?? [])
+    .map((u) => {
+      const p = byId.get(u.id);
+      if (!p) return null;
+      const meta = u.user_metadata as { full_name?: string; must_change_password?: boolean };
+      return {
+        id: u.id,
+        email: u.email ?? '',
+        full_name: p.full_name || meta?.full_name || '',
+        role: p.role as UserRole,
+        is_active: p.is_active,
+        mustChange: meta?.must_change_password === true
+      };
+    })
+    .filter((r): r is NonNullable<typeof r> => r !== null)
+    .sort((a, b) => a.full_name.localeCompare(b.full_name));
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-semibold tracking-tight">{t('title')}</h1>
+        <p className="text-sm text-muted-foreground">{t('subtitle')}</p>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">{t('createHeading')}</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <CreateAccountForm />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">
+            {t('listHeading')} ({rows.length})
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="overflow-x-auto">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>{t('fullName')}</TableHead>
+                  <TableHead>{t('email')}</TableHead>
+                  <TableHead>{t('role')}</TableHead>
+                  <TableHead>{t('status')}</TableHead>
+                  <TableHead className="text-right">{t('actions')}</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {rows.map((r) => (
+                  <TableRow key={r.id}>
+                    <TableCell className="font-medium">{r.full_name || '—'}</TableCell>
+                    <TableCell className="text-muted-foreground">{r.email}</TableCell>
+                    <TableCell>
+                      <Badge variant="secondary">{tRoles(`roles.${r.role}`)}</Badge>
+                    </TableCell>
+                    <TableCell>
+                      <div className="flex flex-wrap gap-1.5">
+                        <Badge variant={r.is_active ? 'secondary' : 'destructive'}>
+                          {r.is_active ? t('active') : t('inactive')}
+                        </Badge>
+                        {r.mustChange && (
+                          <Badge variant="outline" className="text-amber-600 dark:text-amber-500">
+                            {t('mustChange')}
+                          </Badge>
+                        )}
+                      </div>
+                    </TableCell>
+                    <TableCell className="text-right">
+                      <ResetPasswordButton userId={r.id} name={r.full_name || r.email} />
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/[locale]/(dashboard)/dashboard/page.tsx
+++ b/src/app/[locale]/(dashboard)/dashboard/page.tsx
@@ -43,19 +43,20 @@ export default async function DashboardHome({ params }: Props) {
   const today = new Date();
   const monthStart = new Date(today.getFullYear(), today.getMonth(), 1);
 
-  const [profile, t, summary, monthly, recent, stock, users] = await Promise.all([
-    getProfile(),
+  // Cached from the layout's call -- effectively free here.
+  const profile = await getProfile();
+  if (!profile) return null;
+  const role = profile.role as UserRole;
+
+  const [t, summary, monthly, recent, stock, users] = await Promise.all([
     getTranslations('Dashboard'),
     getSalesSummary(toDateInputValue(monthStart), toDateInputValue(today)),
     getMonthlySales(8),
     listRecentSales(6),
     listStock(),
-    countActiveUsers()
+    // Only the Super Admin tile shows this -- skip the query for everyone else.
+    role === 'super_admin' ? countActiveUsers() : Promise.resolve(0)
   ]);
-
-  if (!profile) return null;
-
-  const role = profile.role as UserRole;
   const name = profile.full_name || profile.email;
   const lowItems = stock.filter((p) => p.reorderLevel > 0 && p.quantity <= p.reorderLevel);
   const isReadOnly = role === 'administration';

--- a/src/app/[locale]/(dashboard)/profile/page.tsx
+++ b/src/app/[locale]/(dashboard)/profile/page.tsx
@@ -1,5 +1,6 @@
 import { getTranslations, setRequestLocale } from 'next-intl/server';
 import { getProfile } from '@/actions/auth';
+import { ChangeMyPassword } from '@/components/profile/change-my-password';
 import { ProfileEditor } from '@/components/profile/profile-editor';
 import type { UserRole } from '@/types/database.types';
 
@@ -39,6 +40,8 @@ export default async function ProfilePage({ params }: Props) {
         avatarUrl={profile.avatar_url}
         isActive={profile.is_active}
       />
+
+      <ChangeMyPassword />
     </div>
   );
 }

--- a/src/app/[locale]/change-password/page.tsx
+++ b/src/app/[locale]/change-password/page.tsx
@@ -1,0 +1,54 @@
+import { KeyRoundIcon } from 'lucide-react';
+import { getTranslations, setRequestLocale } from 'next-intl/server';
+import { signOut } from '@/actions/auth';
+import { AuthShell } from '@/components/auth/auth-shell';
+import { ChangePasswordForm } from '@/components/forms/change-password-form';
+import { Button } from '@/components/ui/button';
+
+// Per-user, auth-gated screen -- never prerender it (also keeps the change-password
+// server action from being attached to a static route).
+export const dynamic = 'force-dynamic';
+
+type Props = { params: Promise<{ locale: string }> };
+
+export async function generateMetadata({ params }: Props) {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: 'ChangePassword' });
+  return { title: t('title') };
+}
+
+export default async function ChangePasswordPage({ params }: Props) {
+  const { locale } = await params;
+  setRequestLocale(locale);
+
+  const [t, tNav] = await Promise.all([
+    getTranslations('ChangePassword'),
+    getTranslations('Nav')
+  ]);
+
+  return (
+    <AuthShell
+      topRight={
+        <form action={signOut}>
+          <Button type="submit" variant="ghost" size="sm">
+            {tNav('signOut')}
+          </Button>
+        </form>
+      }
+    >
+      <div className="w-full max-w-md rounded-2xl border bg-card p-7 shadow-xl sm:p-8">
+        <div className="flex flex-col items-center gap-3 text-center">
+          <span className="flex size-16 items-center justify-center rounded-full bg-primary/10 ring-1 ring-border">
+            <KeyRoundIcon className="size-7 text-primary" />
+          </span>
+          <h1 className="text-xl font-semibold tracking-tight">{t('title')}</h1>
+          <p className="text-sm text-muted-foreground">{t('subtitle')}</p>
+        </div>
+
+        <div className="mt-7">
+          <ChangePasswordForm />
+        </div>
+      </div>
+    </AuthShell>
+  );
+}

--- a/src/components/auth/auth-shell.tsx
+++ b/src/components/auth/auth-shell.tsx
@@ -1,5 +1,7 @@
 import { SchoolLogo } from '@/components/brand/school-logo';
 import { SupportButton } from '@/components/auth/support-button';
+import { LanguageSwitcher } from '@/components/language-switcher';
+import { ThemeToggle } from '@/components/theme-toggle';
 import { SCHOOL } from '@/lib/format';
 
 /** Shared frame for the login / forgot-password screens: faded grid background,
@@ -18,7 +20,11 @@ export function AuthShell({
 
       <header className="relative z-10 flex items-center justify-between gap-4 px-6 py-5 sm:px-10">
         <SchoolLogo size="sm" />
-        {topRight}
+        <div className="flex items-center gap-2">
+          {topRight}
+          <LanguageSwitcher />
+          <ThemeToggle />
+        </div>
       </header>
 
       <main className="relative z-10 flex flex-1 items-center justify-center px-4 py-6">

--- a/src/components/dashboard/dashboard-shell.tsx
+++ b/src/components/dashboard/dashboard-shell.tsx
@@ -1,13 +1,14 @@
 'use client';
 
 import { useState } from 'react';
-import { MenuIcon, XIcon, LogOutIcon, BellIcon, SearchIcon } from 'lucide-react';
+import { MenuIcon, XIcon, LogOutIcon, SearchIcon } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { toast } from 'sonner';
 import { Link, usePathname } from '@/i18n/navigation';
 import { signOut } from '@/actions/auth';
 import { SchoolLogo } from '@/components/brand/school-logo';
 import { LanguageSwitcher } from '@/components/language-switcher';
+import { NotificationBell } from '@/components/dashboard/notification-bell';
 import { ThemeToggle } from '@/components/theme-toggle';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -100,16 +101,10 @@ export function DashboardShell({
           <div className="ml-auto flex items-center gap-1.5">
             <LanguageSwitcher />
             <ThemeToggle />
-            <Button
-              variant="ghost"
-              size="icon"
-              aria-label={t('notifications')}
-              onClick={() => toast.info(t('notificationsEmpty'))}
-            >
-              <BellIcon className="size-5" />
-            </Button>
+            <NotificationBell />
             <Link
               href="/profile"
+              prefetch={false}
               title={`${userName} · ${roleLabel}`}
               className="flex size-9 items-center justify-center overflow-hidden rounded-full bg-primary/10 text-sm font-semibold text-primary ring-1 ring-border transition hover:ring-primary/50"
             >
@@ -197,6 +192,7 @@ function SidebarContent({
                   key={item.key}
                   href={item.href}
                   onClick={onNavigate}
+                  prefetch={false}
                   aria-current={active ? 'page' : undefined}
                   className={cls}
                 >

--- a/src/components/dashboard/notification-bell.tsx
+++ b/src/components/dashboard/notification-bell.tsx
@@ -1,0 +1,232 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { BellIcon, InboxIcon, Trash2Icon } from 'lucide-react';
+import { useLocale, useTranslations } from 'next-intl';
+import { useRouter } from '@/i18n/navigation';
+import {
+  listNotifications,
+  markNotificationRead,
+  markAllNotificationsRead,
+  deleteNotification,
+  clearNotifications,
+  type AppNotification
+} from '@/actions/notifications';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from '@/components/ui/dialog';
+import { formatDateTime } from '@/lib/format';
+import { cn } from '@/lib/utils';
+
+export function NotificationBell() {
+  const t = useTranslations('Notifications');
+  const locale = useLocale();
+  const router = useRouter();
+
+  const [items, setItems] = useState<AppNotification[]>([]);
+  const [open, setOpen] = useState(false);
+  const [showAll, setShowAll] = useState(false);
+
+  const refresh = useCallback(async () => setItems(await listNotifications()), []);
+  useEffect(() => {
+    // Fetch on mount inside the promise callback (not synchronously in the
+    // effect body), and ignore the result if we unmounted first.
+    let active = true;
+    listNotifications().then((data) => {
+      if (active) setItems(data);
+    });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const unread = items.filter((i) => !i.is_read).length;
+
+  const text = (n: AppNotification) => {
+    if (n.type === 'password_reset_request') {
+      return {
+        title: t('passwordResetRequest.title'),
+        body: t('passwordResetRequest.body', { email: String(n.data.email ?? '') })
+      };
+    }
+    return { title: t('generic'), body: '' };
+  };
+
+  async function openItem(n: AppNotification) {
+    setOpen(false);
+    setShowAll(false);
+    if (!n.is_read) {
+      setItems((prev) => prev.map((i) => (i.id === n.id ? { ...i, is_read: true } : i)));
+      await markNotificationRead(n.id);
+    }
+    if (n.link) router.push(n.link);
+  }
+
+  async function onDelete(id: string) {
+    setItems((prev) => prev.filter((i) => i.id !== id));
+    await deleteNotification(id);
+  }
+
+  async function onClearAll() {
+    setItems([]);
+    await clearNotifications();
+  }
+
+  async function onMarkAllRead() {
+    setItems((prev) => prev.map((i) => ({ ...i, is_read: true })));
+    await markAllNotificationsRead();
+  }
+
+  return (
+    <>
+      <div className="relative">
+        <Button
+          variant="ghost"
+          size="icon"
+          aria-label={t('title')}
+          onClick={() => {
+            const next = !open;
+            setOpen(next);
+            if (next) refresh();
+          }}
+        >
+          <BellIcon className="size-5" />
+          {unread > 0 && (
+            <span className="absolute right-1 top-1 flex size-4 items-center justify-center rounded-full bg-destructive text-[10px] font-semibold text-white">
+              {unread > 9 ? '9+' : unread}
+            </span>
+          )}
+        </Button>
+
+        {open && (
+          <>
+            <div className="fixed inset-0 z-40" onClick={() => setOpen(false)} />
+            <div className="absolute right-0 z-50 mt-2 w-80 overflow-hidden rounded-xl border bg-popover text-popover-foreground shadow-lg">
+              <div className="flex items-center justify-between border-b px-4 py-2.5">
+                <p className="text-sm font-semibold">{t('title')}</p>
+                {unread > 0 && (
+                  <button
+                    onClick={onMarkAllRead}
+                    className="text-xs font-medium text-primary hover:underline"
+                  >
+                    {t('markAllRead')}
+                  </button>
+                )}
+              </div>
+
+              <div className="max-h-80 overflow-y-auto">
+                {items.length === 0 ? (
+                  <div className="flex flex-col items-center gap-2 px-4 py-8 text-center text-sm text-muted-foreground">
+                    <InboxIcon className="size-6" />
+                    {t('empty')}
+                  </div>
+                ) : (
+                  items.slice(0, 6).map((n) => {
+                    const { title, body } = text(n);
+                    return (
+                      <button
+                        key={n.id}
+                        onClick={() => openItem(n)}
+                        className={cn(
+                          'flex w-full flex-col items-start gap-0.5 border-b px-4 py-3 text-left last:border-0 hover:bg-muted/60',
+                          !n.is_read && 'bg-primary/5'
+                        )}
+                      >
+                        <span className="flex w-full items-center gap-2 text-sm font-medium">
+                          {!n.is_read && <span className="size-1.5 shrink-0 rounded-full bg-primary" />}
+                          {title}
+                        </span>
+                        {body && <span className="line-clamp-2 text-xs text-muted-foreground">{body}</span>}
+                        <span className="text-[11px] text-muted-foreground/70">
+                          {formatDateTime(n.created_at, locale)}
+                        </span>
+                      </button>
+                    );
+                  })
+                )}
+              </div>
+
+              <div className="border-t p-2">
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="w-full"
+                  onClick={() => {
+                    setOpen(false);
+                    setShowAll(true);
+                    refresh();
+                  }}
+                >
+                  {t('seeAll')}
+                </Button>
+              </div>
+            </div>
+          </>
+        )}
+      </div>
+
+      <Dialog open={showAll} onOpenChange={setShowAll}>
+        <DialogContent className="max-w-lg">
+          <DialogHeader>
+            <DialogTitle>{t('allTitle')}</DialogTitle>
+          </DialogHeader>
+
+          <div className="max-h-[60vh] space-y-2 overflow-y-auto">
+            {items.length === 0 ? (
+              <div className="flex flex-col items-center gap-2 py-10 text-center text-sm text-muted-foreground">
+                <InboxIcon className="size-7" />
+                {t('empty')}
+              </div>
+            ) : (
+              items.map((n) => {
+                const { title, body } = text(n);
+                return (
+                  <div
+                    key={n.id}
+                    className={cn(
+                      'flex items-start gap-3 rounded-lg border p-3',
+                      !n.is_read && 'bg-primary/5'
+                    )}
+                  >
+                    <button onClick={() => openItem(n)} className="min-w-0 flex-1 text-left">
+                      <p className="text-sm font-medium">{title}</p>
+                      {body && <p className="text-xs text-muted-foreground">{body}</p>}
+                      <p className="mt-0.5 text-[11px] text-muted-foreground/70">
+                        {formatDateTime(n.created_at, locale)}
+                      </p>
+                    </button>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      aria-label={t('delete')}
+                      onClick={() => onDelete(n.id)}
+                    >
+                      <Trash2Icon className="size-4" />
+                    </Button>
+                  </div>
+                );
+              })
+            )}
+          </div>
+
+          <DialogFooter className="sm:justify-between">
+            <Button
+              variant="ghost"
+              className="text-destructive"
+              onClick={onClearAll}
+              disabled={items.length === 0}
+            >
+              {t('clearAll')}
+            </Button>
+            <Button onClick={() => setShowAll(false)}>{t('close')}</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/src/components/forms/change-password-form.tsx
+++ b/src/components/forms/change-password-form.tsx
@@ -1,0 +1,173 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from '@/i18n/navigation';
+import { EyeIcon, EyeOffIcon, LockKeyholeIcon } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+import { toast } from 'sonner';
+import { changePassword } from '@/actions/auth';
+import { passwordScore } from '@/lib/validation/auth-schema';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Spinner } from '@/components/ui/spinner';
+import { cn } from '@/lib/utils';
+
+type FieldErrors = { current?: string; password?: string; confirm?: string };
+
+export function ChangePasswordForm({
+  redirectOnSuccess = true,
+  onSuccess
+}: {
+  /** After a successful change, navigate to the dashboard (first-login flow). */
+  redirectOnSuccess?: boolean;
+  /** Called after success instead of navigating (inline profile use). */
+  onSuccess?: () => void;
+}) {
+  const t = useTranslations('ChangePassword');
+  const tv = useTranslations('Validation');
+  const router = useRouter();
+
+  const [current, setCurrent] = useState('');
+  const [password, setPassword] = useState('');
+  const [confirm, setConfirm] = useState('');
+  const [show, setShow] = useState(false);
+  const [pending, setPending] = useState(false);
+  const [errors, setErrors] = useState<FieldErrors>({});
+
+  const score = passwordScore(password);
+  const strengthLabel = ['', t('strengthWeak'), t('strengthFair'), t('strengthStrong')][score];
+
+  async function onSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setErrors({});
+    setPending(true);
+    const res = await changePassword({ current, password, confirm });
+    setPending(false);
+
+    if (res.ok) {
+      toast.success(t('success'));
+      if (redirectOnSuccess) {
+        router.replace('/dashboard');
+        router.refresh();
+      } else {
+        setCurrent('');
+        setPassword('');
+        setConfirm('');
+        onSuccess?.();
+        router.refresh();
+      }
+      return;
+    }
+    if (res.fieldErrors) setErrors(res.fieldErrors);
+    else toast.error(t('error'));
+  }
+
+  return (
+    <form onSubmit={onSubmit} className="space-y-5" noValidate>
+      {/* Hidden username field: lets browsers/password managers associate the new
+          password with the account, and clears the a11y warning. */}
+      <input
+        type="text"
+        name="username"
+        autoComplete="username"
+        className="sr-only"
+        tabIndex={-1}
+        aria-hidden
+        readOnly
+      />
+
+      <div className="space-y-1.5">
+        <Label htmlFor="current">{t('currentPassword')}</Label>
+        <div className="relative">
+          <LockKeyholeIcon className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            id="current"
+            type={show ? 'text' : 'password'}
+            value={current}
+            onChange={(e) => setCurrent(e.target.value)}
+            autoComplete="current-password"
+            className="pl-9 pr-9"
+            aria-invalid={Boolean(errors.current)}
+          />
+          <button
+            type="button"
+            onClick={() => setShow((s) => !s)}
+            className="absolute right-2 top-1/2 -translate-y-1/2 rounded p-1 text-muted-foreground hover:text-foreground"
+            aria-label={show ? t('hide') : t('show')}
+          >
+            {show ? <EyeOffIcon className="size-4" /> : <EyeIcon className="size-4" />}
+          </button>
+        </div>
+        {errors.current && <p className="text-sm text-destructive">{tv(errors.current)}</p>}
+      </div>
+
+      <div className="space-y-1.5">
+        <Label htmlFor="password">{t('newPassword')}</Label>
+        <div className="relative">
+          <LockKeyholeIcon className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            id="password"
+            type={show ? 'text' : 'password'}
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            autoComplete="new-password"
+            className="pl-9"
+            aria-invalid={Boolean(errors.password)}
+          />
+        </div>
+        {password && (
+          <div className="flex items-center gap-2 pt-1">
+            <div className="flex flex-1 gap-1">
+              {[1, 2, 3].map((i) => (
+                <span
+                  key={i}
+                  className={cn(
+                    'h-1 flex-1 rounded-full',
+                    i <= score
+                      ? score >= 3
+                        ? 'bg-emerald-500'
+                        : score === 2
+                          ? 'bg-amber-500'
+                          : 'bg-destructive'
+                      : 'bg-muted'
+                  )}
+                />
+              ))}
+            </div>
+            <span className="text-xs text-muted-foreground">{strengthLabel}</span>
+          </div>
+        )}
+        {errors.password ? (
+          <p className="text-sm text-destructive">{tv(errors.password)}</p>
+        ) : (
+          <p className="text-xs text-muted-foreground">{t('hint')}</p>
+        )}
+      </div>
+
+      <div className="space-y-1.5">
+        <Label htmlFor="confirm">{t('confirmPassword')}</Label>
+        <div className="relative">
+          <LockKeyholeIcon className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            id="confirm"
+            type={show ? 'text' : 'password'}
+            value={confirm}
+            onChange={(e) => setConfirm(e.target.value)}
+            autoComplete="new-password"
+            className="pl-9"
+            aria-invalid={Boolean(errors.confirm)}
+          />
+        </div>
+        {errors.confirm && <p className="text-sm text-destructive">{tv(errors.confirm)}</p>}
+      </div>
+
+      <Button type="submit" className="w-full gap-2" disabled={pending}>
+        {pending && (
+          <Spinner className="size-4 border-primary-foreground/40 border-t-primary-foreground" />
+        )}
+        {pending ? t('submitting') : t('submit')}
+      </Button>
+    </form>
+  );
+}

--- a/src/components/forms/create-account-form.tsx
+++ b/src/components/forms/create-account-form.tsx
@@ -1,0 +1,209 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { RefreshCwIcon, CopyIcon, UserPlusIcon } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+import { toast } from 'sonner';
+import { createAccount } from '@/actions/accounts';
+import { ROLES, type Role } from '@/lib/validation/auth-schema';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from '@/components/ui/select';
+import { Spinner } from '@/components/ui/spinner';
+
+function genPassword() {
+  const letters = 'abcdefghjkmnpqrstuvwxyz';
+  const pick = (n: number) =>
+    Array.from({ length: n }, () => letters[Math.floor(Math.random() * letters.length)]).join('');
+  return `Frst-${pick(4)}${Math.floor(1000 + Math.random() * 9000)}`;
+}
+
+type FieldErrors = Partial<Record<'full_name' | 'email' | 'role' | 'password', string>>;
+
+export function CreateAccountForm() {
+  const t = useTranslations('Accounts');
+  const tv = useTranslations('Validation');
+  const tRoles = useTranslations('Dashboard');
+  const router = useRouter();
+
+  const [fullName, setFullName] = useState('');
+  const [email, setEmail] = useState('');
+  const [role, setRole] = useState<Role>('seller');
+  const [password, setPassword] = useState(genPassword);
+  const [pending, setPending] = useState(false);
+  const [errors, setErrors] = useState<FieldErrors>({});
+  const [created, setCreated] = useState<{ email: string; password: string } | null>(null);
+
+  async function onSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setErrors({});
+    setPending(true);
+    const res = await createAccount({ full_name: fullName, email, role, password });
+    setPending(false);
+
+    if (res.ok) {
+      setCreated({ email: res.email, password });
+      setFullName('');
+      setEmail('');
+      setRole('seller');
+      setPassword(genPassword());
+      router.refresh();
+      return;
+    }
+    if (res.fieldErrors) {
+      setErrors(res.fieldErrors);
+      return;
+    }
+    const known = ['forbidden', 'unauthorized', 'createFailed'];
+    if (res.error && /already|registered|exists/i.test(res.error)) {
+      setErrors({ email: 'emailInUse' });
+    } else {
+      toast.error(known.includes(res.error ?? '') ? t(res.error as string) : t('createFailed'));
+    }
+  }
+
+  function copy(text: string) {
+    navigator.clipboard?.writeText(text).then(
+      () => toast.success(t('copied')),
+      () => toast.error(t('createFailed'))
+    );
+  }
+
+  return (
+    <>
+      <form onSubmit={onSubmit} className="space-y-4">
+        <div className="grid gap-4 sm:grid-cols-2">
+          <div className="space-y-1.5">
+            <Label htmlFor="full_name">{t('fullName')}</Label>
+            <Input
+              id="full_name"
+              value={fullName}
+              onChange={(e) => setFullName(e.target.value)}
+              maxLength={120}
+              aria-invalid={Boolean(errors.full_name)}
+            />
+            {errors.full_name && <p className="text-sm text-destructive">{tv(errors.full_name)}</p>}
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="email">{t('email')}</Label>
+            <Input
+              id="email"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              aria-invalid={Boolean(errors.email)}
+            />
+            {errors.email && <p className="text-sm text-destructive">{tv(errors.email)}</p>}
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="role">{t('role')}</Label>
+            <Select value={role} onValueChange={(v) => setRole(v as Role)}>
+              <SelectTrigger id="role">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {ROLES.map((r) => (
+                  <SelectItem key={r} value={r}>
+                    {tRoles(`roles.${r}`)}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="password">{t('tempPassword')}</Label>
+            <div className="flex gap-2">
+              <Input
+                id="password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                aria-invalid={Boolean(errors.password)}
+                className="font-mono"
+              />
+              <Button
+                type="button"
+                variant="outline"
+                size="icon"
+                title={t('generate')}
+                onClick={() => setPassword(genPassword())}
+              >
+                <RefreshCwIcon className="size-4" />
+              </Button>
+            </div>
+            {errors.password && <p className="text-sm text-destructive">{tv(errors.password)}</p>}
+          </div>
+        </div>
+
+        <Button type="submit" className="gap-2" disabled={pending}>
+          {pending ? (
+            <Spinner className="size-4 border-primary-foreground/40 border-t-primary-foreground" />
+          ) : (
+            <UserPlusIcon className="size-4" />
+          )}
+          {pending ? t('creating') : t('createBtn')}
+        </Button>
+      </form>
+
+      <Dialog open={Boolean(created)} onOpenChange={(o) => !o && setCreated(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{t('createdTitle')}</DialogTitle>
+          </DialogHeader>
+          <p className="text-sm text-muted-foreground">{t('createdBody')}</p>
+          {created && (
+            <div className="space-y-2">
+              {(
+                [
+                  { label: t('email'), value: created.email },
+                  { label: t('tempPassword'), value: created.password }
+                ] as const
+              ).map((row) => (
+                <div
+                  key={row.label}
+                  className="flex items-center justify-between gap-3 rounded-lg border bg-muted/40 px-3 py-2"
+                >
+                  <div className="min-w-0">
+                    <p className="text-xs text-muted-foreground">{row.label}</p>
+                    <p className="truncate font-mono text-sm">{row.value}</p>
+                  </div>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    aria-label={t('copy')}
+                    onClick={() => copy(row.value)}
+                  >
+                    <CopyIcon className="size-4" />
+                  </Button>
+                </div>
+              ))}
+            </div>
+          )}
+          <DialogFooter>
+            <Button type="button" onClick={() => setCreated(null)}>
+              {t('done')}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/src/components/forms/forgot-password-form.tsx
+++ b/src/components/forms/forgot-password-form.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { AtSignIcon } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { toast } from 'sonner';
+import { requestPasswordReset } from '@/actions/auth';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -13,7 +14,7 @@ export function ForgotPasswordForm() {
   const t = useTranslations('ForgotPassword');
   const [pending, setPending] = useState(false);
 
-  function onSubmit(e: React.FormEvent<HTMLFormElement>) {
+  async function onSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
     const form = e.currentTarget;
     const email = String(new FormData(form).get('email') ?? '').trim();
@@ -22,14 +23,13 @@ export function ForgotPasswordForm() {
       return;
     }
     setPending(true);
-    // Per A-FR-3.5 there is no self-service email reset: the Super Admin issues a
-    // temporary password. We acknowledge in-app without revealing whether the
-    // address exists, and leave the real notification to a later feature.
-    window.setTimeout(() => {
-      setPending(false);
-      toast.success(t('success'));
-      form.reset();
-    }, 600);
+    // Per A-FR-3.5 there is no self-service email reset: this notifies every Super
+    // Admin in-app so they can issue a temporary password. The response is the
+    // same whether or not the address exists (no account enumeration).
+    await requestPasswordReset(email);
+    setPending(false);
+    toast.success(t('success'));
+    form.reset();
   }
 
   return (

--- a/src/components/forms/reset-password-button.tsx
+++ b/src/components/forms/reset-password-button.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import { useState } from 'react';
+import { KeyRoundIcon, CopyIcon } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+import { toast } from 'sonner';
+import { resetUserPassword } from '@/actions/accounts';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from '@/components/ui/dialog';
+import { Spinner } from '@/components/ui/spinner';
+
+/** Super-Admin action: set a fresh temporary password for a user (or oneself). */
+export function ResetPasswordButton({ userId, name }: { userId: string; name: string }) {
+  const t = useTranslations('Accounts');
+  const [pending, setPending] = useState(false);
+  const [password, setPassword] = useState<string | null>(null);
+
+  async function onReset() {
+    setPending(true);
+    const res = await resetUserPassword(userId);
+    setPending(false);
+    if (res.ok) {
+      setPassword(res.password);
+    } else {
+      toast.error(
+        ['forbidden', 'unauthorized'].includes(res.error) ? t(res.error) : t('resetFailed')
+      );
+    }
+  }
+
+  return (
+    <>
+      <Button
+        variant="outline"
+        size="sm"
+        className="gap-1.5"
+        onClick={onReset}
+        disabled={pending}
+      >
+        {pending ? <Spinner className="size-4" /> : <KeyRoundIcon className="size-4" />}
+        {t('resetPassword')}
+      </Button>
+
+      <Dialog open={Boolean(password)} onOpenChange={(o) => !o && setPassword(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{t('resetDoneTitle')}</DialogTitle>
+          </DialogHeader>
+          <p className="text-sm text-muted-foreground">{t('resetDoneBody', { name })}</p>
+          {password && (
+            <div className="flex items-center justify-between gap-3 rounded-lg border bg-muted/40 px-3 py-2">
+              <div className="min-w-0">
+                <p className="text-xs text-muted-foreground">{t('tempPassword')}</p>
+                <p className="truncate font-mono text-sm">{password}</p>
+              </div>
+              <Button
+                variant="ghost"
+                size="icon"
+                aria-label={t('copy')}
+                onClick={() => {
+                  navigator.clipboard?.writeText(password);
+                  toast.success(t('copied'));
+                }}
+              >
+                <CopyIcon className="size-4" />
+              </Button>
+            </div>
+          )}
+          <DialogFooter>
+            <Button onClick={() => setPassword(null)}>{t('done')}</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/src/components/profile/change-my-password.tsx
+++ b/src/components/profile/change-my-password.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import { useState } from 'react';
+import { KeyRoundIcon } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+import { ChangePasswordForm } from '@/components/forms/change-password-form';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle
+} from '@/components/ui/dialog';
+
+/** Change-your-own-password, inline on the profile (dashboard-gated). */
+export function ChangeMyPassword() {
+  const t = useTranslations('ChangePassword');
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <Button variant="outline" className="gap-2" onClick={() => setOpen(true)}>
+        <KeyRoundIcon className="size-4" />
+        {t('title')}
+      </Button>
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{t('title')}</DialogTitle>
+          </DialogHeader>
+          <ChangePasswordForm redirectOnSuccess={false} onSuccess={() => setOpen(false)} />
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/src/components/theme-toggle.tsx
+++ b/src/components/theme-toggle.tsx
@@ -1,19 +1,18 @@
 'use client';
 
-import { useEffect, useState } from 'react';
 import { useTheme } from 'next-themes';
 import { MoonIcon, SunIcon } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { Button } from '@/components/ui/button';
 
-/** Light/dark switch for the top bar. Guards against hydration mismatch. */
+/**
+ * Light/dark switch for the top bar. The icon is chosen with CSS (`dark:`) so
+ * there's no hydration mismatch and no mount-guard effect; the click reads the
+ * resolved theme (only ever fired after hydration).
+ */
 export function ThemeToggle() {
   const t = useTranslations('Nav');
   const { resolvedTheme, setTheme } = useTheme();
-  const [mounted, setMounted] = useState(false);
-  useEffect(() => setMounted(true), []);
-
-  const isDark = mounted && resolvedTheme === 'dark';
 
   return (
     <Button
@@ -21,9 +20,10 @@ export function ThemeToggle() {
       size="icon"
       aria-label={t('toggleTheme')}
       title={t('toggleTheme')}
-      onClick={() => setTheme(isDark ? 'light' : 'dark')}
+      onClick={() => setTheme(resolvedTheme === 'dark' ? 'light' : 'dark')}
     >
-      {isDark ? <SunIcon className="size-5" /> : <MoonIcon className="size-5" />}
+      <SunIcon className="hidden size-5 dark:block" />
+      <MoonIcon className="size-5 dark:hidden" />
     </Button>
   );
 }

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -39,7 +39,7 @@ function DialogOverlay({
     <DialogPrimitive.Overlay
       data-slot="dialog-overlay"
       className={cn(
-        "fixed inset-0 isolate z-50 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
+        "fixed inset-0 isolate z-50 bg-foreground/25 duration-100 supports-backdrop-filter:backdrop-blur-sm data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
         className
       )}
       {...props}

--- a/src/lib/dashboard-nav.ts
+++ b/src/lib/dashboard-nav.ts
@@ -44,7 +44,7 @@ export const NAV_ITEMS: readonly NavItem[] = [
   { key: 'audit', icon: ScrollText, section: 'records', roles: ALL },
 
   { key: 'catalogue', icon: Tags, section: 'admin', roles: ALL },
-  { key: 'accounts', icon: Users, section: 'admin', roles: ['super_admin'] }
+  { key: 'accounts', href: '/accounts', icon: Users, section: 'admin', roles: ['super_admin'] }
 ];
 
 export const NAV_SECTION_ORDER: readonly NavSection[] = [

--- a/src/lib/supabase/admin.ts
+++ b/src/lib/supabase/admin.ts
@@ -1,0 +1,21 @@
+import { createClient } from '@supabase/supabase-js';
+import type { Database } from '@/types/database.types';
+
+/**
+ * Service-role Supabase client. **Bypasses RLS** — never import this into a
+ * Client Component, and only call it after verifying the caller server-side.
+ * Used for the admin-only user-management operations (creating accounts).
+ *
+ * Only ever call from Server Actions / Server Components: the service-role key is
+ * a server-only env var, so a browser import throws here rather than leaking it.
+ */
+export function createAdminClient() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !serviceKey) {
+    throw new Error('Supabase admin client requires NEXT_PUBLIC_SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY.');
+  }
+  return createClient<Database>(url, serviceKey, {
+    auth: { autoRefreshToken: false, persistSession: false }
+  });
+}

--- a/src/lib/validation/auth-schema.ts
+++ b/src/lib/validation/auth-schema.ts
@@ -20,3 +20,54 @@ export type LoginState = {
 };
 
 export const emptyLoginState: LoginState = { error: null, fieldErrors: {} };
+
+// --- passwords -------------------------------------------------------------
+
+/** Minimum length + a basic strength check (at least one letter and one digit). */
+export const passwordSchema = z
+  .string()
+  .min(8, { message: 'passwordShort' })
+  .regex(/[A-Za-z]/, { message: 'passwordLetter' })
+  .regex(/[0-9]/, { message: 'passwordNumber' });
+
+export const changePasswordSchema = z
+  .object({
+    current: z.string().min(1, { message: 'required' }),
+    password: passwordSchema,
+    confirm: z.string()
+  })
+  .refine((d) => d.password === d.confirm, {
+    path: ['confirm'],
+    message: 'passwordMismatch'
+  })
+  .refine((d) => d.password !== d.current, {
+    path: ['password'],
+    message: 'passwordSame'
+  });
+
+export type ChangePasswordInput = z.infer<typeof changePasswordSchema>;
+
+/** A rough 0–3 strength score for the meter (length + character variety). */
+export function passwordScore(value: string): 0 | 1 | 2 | 3 {
+  if (!value) return 0;
+  let score = 0;
+  if (value.length >= 8) score++;
+  if (/[A-Za-z]/.test(value) && /[0-9]/.test(value)) score++;
+  if (value.length >= 12 && /[^A-Za-z0-9]/.test(value)) score++;
+  return score as 0 | 1 | 2 | 3;
+}
+
+// --- accounts (Super Admin creates users) ----------------------------------
+
+/** The fixed role set (spec A-2). There is deliberately no way to add roles. */
+export const ROLES = ['seller', 'administration', 'maintenance', 'super_admin'] as const;
+export type Role = (typeof ROLES)[number];
+
+export const createAccountSchema = z.object({
+  full_name: z.string().trim().min(1, { message: 'required' }).max(120),
+  email: z.email({ message: 'invalidEmail' }).trim().toLowerCase(),
+  role: z.enum(ROLES),
+  password: passwordSchema
+});
+
+export type CreateAccountInput = z.infer<typeof createAccountSchema>;

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -35,6 +35,17 @@ export async function proxy(request: NextRequest) {
     (path) => pathname === path || pathname.startsWith(`${path}/`)
   );
 
+  // First-login gate (A-FR-3.2): a signed-in user still carrying the
+  // must_change_password flag is forced onto /change-password and can reach
+  // nothing else until it is cleared. Server-side, so the UI cannot skip it.
+  if (
+    user &&
+    user.user_metadata?.must_change_password === true &&
+    pathname !== '/change-password'
+  ) {
+    return NextResponse.redirect(new URL(`/${locale}/change-password`, request.url));
+  }
+
   if (!user && !isPublic) {
     const loginUrl = new URL(`/${locale}/login`, request.url);
     if (pathname !== '/') {

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -51,6 +51,36 @@ export type Database = {
         };
         Relationships: [];
       };
+      notifications: {
+        Row: {
+          id: string;
+          user_id: string;
+          type: string;
+          data: Json;
+          link: string | null;
+          is_read: boolean;
+          created_at: string;
+        };
+        Insert: {
+          id?: string;
+          user_id: string;
+          type: string;
+          data?: Json;
+          link?: string | null;
+          is_read?: boolean;
+          created_at?: string;
+        };
+        Update: {
+          id?: string;
+          user_id?: string;
+          type?: string;
+          data?: Json;
+          link?: string | null;
+          is_read?: boolean;
+          created_at?: string;
+        };
+        Relationships: [];
+      };
       products: {
         Row: {
           id: string;

--- a/supabase/migrations/20260101000400_notifications.sql
+++ b/supabase/migrations/20260101000400_notifications.sql
@@ -1,0 +1,18 @@
+-- In-app notifications, one row per recipient. Text is not stored: rows carry a
+-- `type` + `data` and the UI renders the (bilingual) label, so notifications
+-- respect P-5 like everything else. Created server-side (service role) only.
+
+create table public.notifications (
+  id          uuid primary key default gen_random_uuid(),
+  user_id     uuid not null references public.profiles (id) on delete cascade,
+  type        text not null,
+  data        jsonb not null default '{}',
+  link        text,               -- internal path to the linked feature
+  is_read     boolean not null default false,
+  created_at  timestamptz not null default now()
+);
+
+create index notifications_user_idx
+  on public.notifications (user_id, is_read, created_at desc);
+
+alter table public.notifications enable row level security;

--- a/supabase/migrations/rollback/20260101000400_notifications_down.sql
+++ b/supabase/migrations/rollback/20260101000400_notifications_down.sql
@@ -1,0 +1,4 @@
+-- Rollback of 20260101000400_notifications.sql. Manual (see the header in
+-- rollback/20260101000000_init_down.sql).
+
+drop table if exists public.notifications cascade;

--- a/supabase/policies/05_notifications.sql
+++ b/supabase/policies/05_notifications.sql
@@ -1,0 +1,23 @@
+-- Notifications belong to their recipient. They are inserted server-side with the
+-- service role (the forgot-password requester isn't even signed in), so no insert
+-- policy is granted to normal users -- only reading, marking read, and deleting
+-- one's own.
+
+drop policy if exists "notifications_select_own" on public.notifications;
+create policy "notifications_select_own"
+  on public.notifications for select
+  to authenticated
+  using (user_id = (select auth.uid()));
+
+drop policy if exists "notifications_update_own" on public.notifications;
+create policy "notifications_update_own"
+  on public.notifications for update
+  to authenticated
+  using (user_id = (select auth.uid()))
+  with check (user_id = (select auth.uid()));
+
+drop policy if exists "notifications_delete_own" on public.notifications;
+create policy "notifications_delete_own"
+  on public.notifications for delete
+  to authenticated
+  using (user_id = (select auth.uid()));


### PR DESCRIPTION
# feat(auth): account management, forced first-login password change, resets & in-app notifications

## Summary

Implements Phase 1 authentication and account management, plus a full in-app notification system and a Super-Admin-driven password-reset flow. Enforcement is server-side per §A-2 — hiding a button is not a permission check.

## Auth & accounts (A-FR-3.1, A-FR-3.2)

- **No public sign-up** — the app has no registration route or `signUp` call.
- **Super Admin creates accounts** (`/accounts`) with a role from the fixed set and a temporary password. Enforced server-side: `createAccount` refuses any non-super-admin caller before the service-role client runs.
- **Forced first-login change** — new accounts carry `must_change_password`; the proxy redirects such users to `/change-password` and blocks everything else until they change it.
- **Password strength** — min 8 chars incl. a letter and a number, validated in the server action (not just the UI), with a strength meter.
- **No role editor** — roles are a fixed enum; there is no UI to add or edit roles.

## Password management

- **Change password** now requires the **current password** (verified via a throwaway sign-in that doesn't disturb the live session) and rejects reusing the same password. Available on `/change-password` and **inline on the profile** (dashboard-gated).
- **Super Admin can reset any user's password (incl. their own)** from the Accounts table — sets a fresh temp password + re-flags forced change; returns the password to share securely.
- **Forgot password → Super Admin notified** (A-FR-3.5: no self-service email reset). Requesting a reset notifies every active Super Admin in-app; the response is identical whether or not the address exists (no account enumeration).
- **`npm run db:reset:passwords`** — one-shot tool to reset every account to the shared temp password and force a change on next login.

## In-app notifications

- New `notifications` table (per-recipient; `type` + JSON `data` + `link`; rows created server-side only). Text is rendered bilingually from `type` (P-5).
- **Bell** with unread badge → dropdown of recent items; clicking one marks it read and navigates to the linked feature. **Mark all as read**.
- **"See all notifications"** → modal with a **blurred backdrop**, per-item **delete**, and **clear all**.

## Auth-screen UX

- **Language switcher + light/dark toggle** added to the login, forgot-password, and change-password screens.

## Perf / a11y

- `getProfile()` memoised per request (was running twice per load); user-count query skipped for non-super-admins.
- Sidebar links use `prefetch={false}` so dev stops compiling every route on dashboard load.
- Hidden username field on the change-password form (password-manager a11y).

## Database changes

Apply after merge:

```bash
npm run db:push        # creates the notifications table (migration 20260101000400)
npm run db:policies    # applies 05_notifications.sql
```

Rollback lives in `supabase/migrations/rollback/`.

## Testing

- **No sign-up:** no registration URL exists; disable Supabase sign-ups as the server backstop (`POST /auth/v1/signup` refused).
- **Create + first login:** Super Admin creates a user → that user logs in with the temp password → forced to `/change-password` (can't skip) → after changing (entering the current temp password) reaches the app.
- **Reset:** Super Admin resets any user (or self) → temp password shown → user forced to change on next login.
- **Forgot → notify:** request a reset for a real email → the Super Admin's bell shows it → click → Accounts → reset.
- **Notifications:** verify the bell badge, dropdown, click-through, and the "all" modal with delete / clear.
- **Auth-screen switchers:** language + light/dark toggle work on login, forgot-password, and change-password.

## Notes

- Notifications are fetched on bell mount/open (not live-pushed); real-time can be added later.
- Requires `npm run db:push` + `npm run db:policies` before the bell / reset-request flow works.
- `.idea/` editor files are intentionally not committed.

