### PR TITLE
PR/Auth rate limiting and Audit log

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -102,6 +102,21 @@
       "body": "{email} needs a new password. Open Accounts to set a temporary one."
     }
   },
+  "Audit": {
+    "title": "Audit log",
+    "subtitle": "Every recorded action, including failed sign-ins. Append-only.",
+    "recent": "Recent entries",
+    "empty": "No entries yet.",
+    "time": "Time",
+    "action": "Action",
+    "actor": "Account",
+    "ip": "IP",
+    "actions": {
+      "login_failed": "Failed login",
+      "login_blocked": "Login blocked",
+      "login_success": "Signed in"
+    }
+  },
   "Profile": {
     "title": "My profile",
     "subtitle": "Your account details.",
@@ -200,7 +215,9 @@
     "submit": "Sign in",
     "submitting": "Signing in\u2026",
     "invalidCredentials": "Incorrect email or password.",
-    "unexpectedError": "Something went wrong. Please try again."
+    "unexpectedError": "Something went wrong. Please try again.",
+    "tooManyAttempts": "Too many failed attempts. Try again in a few minutes.",
+    "sessionExpired": "Your session expired. Please sign in again."
   },
   "Sales": {
     "title": "New sale",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -102,6 +102,21 @@
       "body": "{email} a besoin d'un nouveau mot de passe. Ouvrez Comptes pour en d\u00e9finir un temporaire."
     }
   },
+  "Audit": {
+    "title": "Journal d'audit",
+    "subtitle": "Chaque action enregistr\u00e9e, y compris les \u00e9checs de connexion. En ajout seul.",
+    "recent": "Entr\u00e9es r\u00e9centes",
+    "empty": "Aucune entr\u00e9e pour le moment.",
+    "time": "Heure",
+    "action": "Action",
+    "actor": "Compte",
+    "ip": "IP",
+    "actions": {
+      "login_failed": "\u00c9chec de connexion",
+      "login_blocked": "Connexion bloqu\u00e9e",
+      "login_success": "Connect\u00e9"
+    }
+  },
   "Profile": {
     "title": "Mon profil",
     "subtitle": "Les informations de votre compte.",
@@ -200,7 +215,9 @@
     "submit": "Se connecter",
     "submitting": "Connexion\u2026",
     "invalidCredentials": "E-mail ou mot de passe incorrect.",
-    "unexpectedError": "Une erreur est survenue. Veuillez r\u00e9essayer."
+    "unexpectedError": "Une erreur est survenue. Veuillez r\u00e9essayer.",
+    "tooManyAttempts": "Trop de tentatives \u00e9chou\u00e9es. R\u00e9essayez dans quelques minutes.",
+    "sessionExpired": "Votre session a expir\u00e9. Veuillez vous reconnecter."
   },
   "Sales": {
     "title": "Nouvelle vente",

--- a/src/actions/auth.ts
+++ b/src/actions/auth.ts
@@ -1,10 +1,12 @@
 'use server';
 
 import { cache } from 'react';
+import { cookies, headers } from 'next/headers';
 import { revalidatePath } from 'next/cache';
 import { getLocale } from 'next-intl/server';
 import { createClient as createSupabaseJsClient } from '@supabase/supabase-js';
 import { redirect } from '@/i18n/navigation';
+import { logAudit, countRecentFailedLogins } from '@/lib/audit';
 import { createClient } from '@/lib/supabase/server';
 import { createAdminClient } from '@/lib/supabase/admin';
 import { requireSupabaseEnv } from '@/lib/supabase/env';
@@ -14,6 +16,13 @@ import {
   loginSchema,
   type LoginState
 } from '@/lib/validation/auth-schema';
+
+async function getClientIp(): Promise<string | null> {
+  const h = await headers();
+  const fwd = h.get('x-forwarded-for');
+  if (fwd) return fwd.split(',')[0].trim();
+  return h.get('x-real-ip');
+}
 
 export async function signIn(
   _prevState: LoginState,
@@ -36,16 +45,38 @@ export async function signIn(
     return { error: null, fieldErrors };
   }
 
+  const email = parsed.data.email;
+  const ip = await getClientIp();
+
+  // Rate limit: after 5 failed attempts in 5 minutes, lock this email out until
+  // the failures age out of the window. The 6th attempt in a row is refused.
+  if ((await countRecentFailedLogins(email)) >= 5) {
+    await logAudit({ action: 'login_blocked', ip, meta: { email } });
+    return { error: 'tooManyAttempts', fieldErrors: {} };
+  }
+
   const supabase = await createClient();
-  const { error } = await supabase.auth.signInWithPassword({
-    email: parsed.data.email,
+  const { data, error } = await supabase.auth.signInWithPassword({
+    email,
     password: parsed.data.password
   });
 
   if (error) {
+    await logAudit({ action: 'login_failed', ip, meta: { email } });
     // Deliberately vague: don't reveal whether the address has an account.
     return { error: 'invalidCredentials', fieldErrors: {} };
   }
+
+  await logAudit({ actorId: data.user?.id ?? null, action: 'login_success', ip, meta: { email } });
+
+  // Stamp the session start so the proxy can enforce a per-role timeout.
+  const cookieStore = await cookies();
+  cookieStore.set('session_started', String(Date.now()), {
+    httpOnly: true,
+    sameSite: 'lax',
+    path: '/',
+    secure: process.env.NODE_ENV === 'production'
+  });
 
   const locale = await getLocale();
   revalidatePath('/', 'layout');

--- a/src/app/[locale]/(auth)/login/page.tsx
+++ b/src/app/[locale]/(auth)/login/page.tsx
@@ -5,7 +5,7 @@ import { LoginForm } from '@/components/forms/login-form';
 
 type Props = {
   params: Promise<{ locale: string }>;
-  searchParams: Promise<{ redirectTo?: string }>;
+  searchParams: Promise<{ redirectTo?: string; expired?: string }>;
 };
 
 export async function generateMetadata({ params }: Props) {
@@ -18,7 +18,7 @@ export default async function LoginPage({ params, searchParams }: Props) {
   const { locale } = await params;
   setRequestLocale(locale);
 
-  const { redirectTo } = await searchParams;
+  const { redirectTo, expired } = await searchParams;
   const t = await getTranslations('Login');
 
   // Only ever accept a same-origin path -- an absolute URL here would turn the
@@ -35,6 +35,12 @@ export default async function LoginPage({ params, searchParams }: Props) {
           </span>
           <h1 className="text-xl font-semibold tracking-tight">{t('heading')}</h1>
         </div>
+
+        {expired && (
+          <div className="mt-4 rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-center text-sm text-amber-700 dark:text-amber-400">
+            {t('sessionExpired')}
+          </div>
+        )}
 
         <div className="mt-7">
           <LoginForm redirectTo={safeRedirect} />

--- a/src/app/[locale]/(dashboard)/audit/page.tsx
+++ b/src/app/[locale]/(dashboard)/audit/page.tsx
@@ -1,0 +1,102 @@
+import { getTranslations, setRequestLocale } from 'next-intl/server';
+import { createClient } from '@/lib/supabase/server';
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow
+} from '@/components/ui/table';
+import { formatDateTime } from '@/lib/format';
+
+type Props = { params: Promise<{ locale: string }> };
+
+const KNOWN_ACTIONS = ['login_failed', 'login_blocked', 'login_success'];
+
+export async function generateMetadata({ params }: Props) {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: 'Audit' });
+  return { title: t('title') };
+}
+
+export default async function AuditPage({ params }: Props) {
+  const { locale } = await params;
+  setRequestLocale(locale);
+
+  const [t, supabase] = await Promise.all([getTranslations('Audit'), createClient()]);
+
+  // Readable by every role (A-FR-11.4) via the audit_select_all policy.
+  const { data } = await supabase
+    .from('audit_log')
+    .select('id, action, ip, meta, created_at')
+    .order('created_at', { ascending: false })
+    .limit(100);
+
+  const rows = data ?? [];
+
+  const actionLabel = (action: string) =>
+    KNOWN_ACTIONS.includes(action) ? t(`actions.${action}`) : action;
+  const actionVariant = (action: string) =>
+    action === 'login_failed' || action === 'login_blocked' ? 'destructive' : 'secondary';
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-semibold tracking-tight">{t('title')}</h1>
+        <p className="text-sm text-muted-foreground">{t('subtitle')}</p>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">
+            {t('recent')} ({rows.length})
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="overflow-x-auto">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>{t('time')}</TableHead>
+                  <TableHead>{t('action')}</TableHead>
+                  <TableHead>{t('actor')}</TableHead>
+                  <TableHead>{t('ip')}</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {rows.length === 0 ? (
+                  <TableRow>
+                    <TableCell colSpan={4} className="py-8 text-center text-muted-foreground">
+                      {t('empty')}
+                    </TableCell>
+                  </TableRow>
+                ) : (
+                  rows.map((r) => {
+                    const meta = (r.meta as { email?: string }) ?? {};
+                    return (
+                      <TableRow key={r.id}>
+                        <TableCell className="whitespace-nowrap text-muted-foreground">
+                          {formatDateTime(r.created_at, locale)}
+                        </TableCell>
+                        <TableCell>
+                          <Badge variant={actionVariant(r.action)}>{actionLabel(r.action)}</Badge>
+                        </TableCell>
+                        <TableCell className="font-medium">{meta.email ?? '—'}</TableCell>
+                        <TableCell className="font-mono text-xs text-muted-foreground">
+                          {r.ip ?? '—'}
+                        </TableCell>
+                      </TableRow>
+                    );
+                  })
+                )}
+              </TableBody>
+            </Table>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/forms/login-form.tsx
+++ b/src/components/forms/login-form.tsx
@@ -35,13 +35,14 @@ export function LoginForm({ redirectTo }: { redirectTo: string | null }) {
 
   // Surface the general auth error as an in-app toast (field errors stay inline).
   useEffect(() => {
-    if (state.error) {
-      toast.error(
-        state.error === 'invalidCredentials'
-          ? t('invalidCredentials')
-          : t('unexpectedError')
-      );
-    }
+    if (!state.error) return;
+    const message =
+      state.error === 'invalidCredentials'
+        ? t('invalidCredentials')
+        : state.error === 'tooManyAttempts'
+          ? t('tooManyAttempts')
+          : t('unexpectedError');
+    toast.error(message);
   }, [state, t]);
 
   return (

--- a/src/lib/audit.ts
+++ b/src/lib/audit.ts
@@ -1,0 +1,46 @@
+import { createAdminClient } from '@/lib/supabase/admin';
+import type { Json } from '@/types/database.types';
+
+/**
+ * Appends an entry to the audit log. Uses the service role because some events
+ * (failed logins) happen with no signed-in user. Never throws -- auditing must
+ * not break the request it is recording.
+ */
+export async function logAudit(entry: {
+  actorId?: string | null;
+  action: string;
+  entity?: string | null;
+  ip?: string | null;
+  meta?: Record<string, unknown>;
+}) {
+  try {
+    const admin = createAdminClient();
+    await admin.from('audit_log').insert({
+      actor_id: entry.actorId ?? null,
+      action: entry.action,
+      entity: entry.entity ?? null,
+      ip: entry.ip ?? null,
+      meta: (entry.meta ?? {}) as Json
+    });
+  } catch {
+    // swallow
+  }
+}
+
+/** Failed sign-ins for `email` within the window (default 5 min) -- drives the
+ * login lockout. */
+export async function countRecentFailedLogins(email: string, windowMs = 5 * 60 * 1000) {
+  try {
+    const admin = createAdminClient();
+    const since = new Date(Date.now() - windowMs).toISOString();
+    const { count } = await admin
+      .from('audit_log')
+      .select('id', { count: 'exact', head: true })
+      .eq('action', 'login_failed')
+      .gte('created_at', since)
+      .contains('meta', { email });
+    return count ?? 0;
+  } catch {
+    return 0;
+  }
+}

--- a/src/lib/dashboard-nav.ts
+++ b/src/lib/dashboard-nav.ts
@@ -41,7 +41,7 @@ export const NAV_ITEMS: readonly NavItem[] = [
 
   { key: 'receipts', icon: Receipt, section: 'records', roles: ALL },
   { key: 'reports', href: '/reports', icon: BarChart3, section: 'records', roles: ALL },
-  { key: 'audit', icon: ScrollText, section: 'records', roles: ALL },
+  { key: 'audit', href: '/audit', icon: ScrollText, section: 'records', roles: ALL },
 
   { key: 'catalogue', icon: Tags, section: 'admin', roles: ALL },
   { key: 'accounts', href: '/accounts', icon: Users, section: 'admin', roles: ['super_admin'] }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -35,6 +35,38 @@ export async function proxy(request: NextRequest) {
     (path) => pathname === path || pathname.startsWith(`${path}/`)
   );
 
+  // Per-role session timeout (A-FR-3.4): 12h for the Seller, 2h for everyone
+  // else, measured from the `session_started` stamp set at login. Role comes from
+  // the JWT (app_metadata) so this needs no DB query. On expiry we clear the
+  // auth cookies and bounce to login with an "expired" notice.
+  if (user) {
+    const role = (user.app_metadata?.role as string | undefined) ?? '';
+    const limitMs = role === 'seller' ? 12 * 60 * 60 * 1000 : 2 * 60 * 60 * 1000;
+    const startedRaw = request.cookies.get('session_started')?.value;
+    const started = startedRaw ? Number(startedRaw) : NaN;
+
+    if (Number.isFinite(started) && Date.now() - started > limitMs) {
+      const url = new URL(`/${locale}/login`, request.url);
+      url.searchParams.set('expired', '1');
+      const expired = NextResponse.redirect(url);
+      for (const cookie of request.cookies.getAll()) {
+        if (cookie.name.startsWith('sb-')) expired.cookies.delete(cookie.name);
+      }
+      expired.cookies.delete('session_started');
+      return expired;
+    }
+
+    if (!Number.isFinite(started)) {
+      // Session that predates this feature: start its clock now.
+      response.cookies.set('session_started', String(Date.now()), {
+        httpOnly: true,
+        sameSite: 'lax',
+        path: '/',
+        secure: process.env.NODE_ENV === 'production'
+      });
+    }
+  }
+
   // First-login gate (A-FR-3.2): a signed-in user still carrying the
   // must_change_password flag is forced onto /change-password and can reach
   // nothing else until it is cleared. Server-side, so the UI cannot skip it.

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -81,6 +81,36 @@ export type Database = {
         };
         Relationships: [];
       };
+      audit_log: {
+        Row: {
+          id: string;
+          actor_id: string | null;
+          action: string;
+          entity: string | null;
+          ip: string | null;
+          meta: Json;
+          created_at: string;
+        };
+        Insert: {
+          id?: string;
+          actor_id?: string | null;
+          action: string;
+          entity?: string | null;
+          ip?: string | null;
+          meta?: Json;
+          created_at?: string;
+        };
+        Update: {
+          id?: string;
+          actor_id?: string | null;
+          action?: string;
+          entity?: string | null;
+          ip?: string | null;
+          meta?: Json;
+          created_at?: string;
+        };
+        Relationships: [];
+      };
       products: {
         Row: {
           id: string;

--- a/supabase/migrations/20260101000500_audit_log.sql
+++ b/supabase/migrations/20260101000500_audit_log.sql
@@ -1,0 +1,19 @@
+-- Audit log (spec A-11). Append-only: no update/delete policy is ever granted,
+-- for any role including Super Admin (A-FR-11.3). Readable by every role
+-- (A-FR-11.4). Rows are written server-side with the service role -- including
+-- for signed-out events like failed logins, which have no actor.
+
+create table public.audit_log (
+  id          uuid primary key default gen_random_uuid(),
+  actor_id    uuid references public.profiles (id) on delete set null,
+  action      text not null,          -- e.g. login_failed, login_blocked, login_success
+  entity      text,                   -- optional target descriptor
+  ip          text,                   -- best-effort client IP
+  meta        jsonb not null default '{}',
+  created_at  timestamptz not null default now()
+);
+
+create index audit_log_created_idx on public.audit_log (created_at desc);
+create index audit_log_action_created_idx on public.audit_log (action, created_at desc);
+
+alter table public.audit_log enable row level security;

--- a/supabase/migrations/rollback/20260101000500_audit_log_down.sql
+++ b/supabase/migrations/rollback/20260101000500_audit_log_down.sql
@@ -1,0 +1,4 @@
+-- Rollback of 20260101000500_audit_log.sql. Manual (see the header in
+-- rollback/20260101000000_init_down.sql).
+
+drop table if exists public.audit_log cascade;

--- a/supabase/policies/06_audit_log.sql
+++ b/supabase/policies/06_audit_log.sql
@@ -1,0 +1,10 @@
+-- The audit log is readable by every signed-in role (A-FR-11.4) and is
+-- append-only (A-FR-11.3): no insert / update / delete policy is granted to
+-- anyone, so entries can only be written by trusted server code (service role)
+-- and can never be edited or removed through the app.
+
+drop policy if exists "audit_select_all" on public.audit_log;
+create policy "audit_select_all"
+  on public.audit_log for select
+  to authenticated
+  using (true);


### PR DESCRIPTION
# feat(auth): login rate-limiting, failed-login audit log, and per-role session timeouts

## Summary

Adds the auth security layer for Phase 1: brute-force protection on login, an append-only audit log that records every failed sign-in (with IP when available), and per-role session timeouts. Super-Admin password reset + forced first-login change (this scope's tasks 4–5) already shipped in the merged auth PR, so no new work was needed there.

## Failed-login rate limit (A-NFR / A-3)

- After **5 failed attempts for an email within 5 minutes**, further attempts are **locked out** ("Too many failed attempts…") — the 6th wrong password in a row is refused without hitting Supabase.
- Rolling window (natural backoff): the lock clears as failures age past 5 minutes.

## Audit log (A-11)

- New `audit_log` table — **append-only** (no update/delete policy for anyone, incl. Super Admin, per A-FR-11.3) and **readable by every role** (A-FR-11.4). Rows are written server-side with the service role, so signed-out events (failed logins) can be recorded.
- Every login is logged: `login_failed`, `login_blocked`, `login_success`, each with the email and best-effort client **IP** (`x-forwarded-for` / `x-real-ip`).
- New **Audit log** screen (`/audit`, in the sidebar) lists recent entries.

## Per-role session timeout (A-FR-3.4)

- **12 hours for the Seller, 2 hours for every other role**, measured from a `session_started` stamp set at login.
- Enforced in the proxy on every request; the role is read from the JWT (`app_metadata.role`), so there's no extra DB query. Timeout is **absolute** from login — token refreshes don't extend it.
- On expiry the auth cookies are cleared and the user is bounced to `/login?expired=1` with a "session expired" notice. Pre-existing sessions get their clock started lazily.

## Database changes

Apply after merge:

```bash
npm run db:push        # creates audit_log (migration 20260101000500)
npm run db:policies    # applies 06_audit_log.sql
```

Rollback lives in `supabase/migrations/rollback/`.

## Testing

- **Rate limit:** 5 wrong passwords for a real email → each "Incorrect email or password."; the **6th** → **lockout**. Unlocks after 5 minutes (or by clearing the `login_failed` rows).
- **Audit:** open **Records → Audit log** — failed/blocked/successful logins appear with email + IP.
- **Session timeout:** simulate via **DevTools → Application → Cookies → `session_started`** (a ms timestamp): set it **> 2 h ago** for a non-seller (e.g. `superadmin`) → next navigation redirects to `/login?expired=1`; for the seller (`ateba`), only **> 12 h ago** expires.
- **Reset (already shipped):** `/accounts` → per-user **Reset password** → temp password → forced change on next login.

## Files

**Created**

```
supabase/migrations/20260101000500_audit_log.sql
supabase/migrations/rollback/20260101000500_audit_log_down.sql
supabase/policies/06_audit_log.sql
src/lib/audit.ts
src/app/[locale]/(dashboard)/audit/page.tsx
```

**Modified**

```
src/types/database.types.ts
src/actions/auth.ts
src/proxy.ts
src/app/[locale]/(auth)/login/page.tsx
src/components/forms/login-form.tsx
src/lib/dashboard-nav.ts
messages/en.json
messages/fr.json
```

## Notes

- Requires `npm run db:push` + `npm run db:policies` before rate-limiting and the audit log work.
- IP is best-effort — usually empty on localhost, populated behind Vercel/a proxy.
- `.idea/` editor files are intentionally not committed.
