### PR TITLE
PR/feat(production): show waiting-order count when entering production

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -450,6 +450,7 @@
     "recording": "Recording…",
     "batchTotal": "{units} garments across {lines} line(s)",
     "success": "{units} garments recorded across {lines} line(s).",
+    "waitingOrders": "{orders} order(s) waiting for this size — {units} garment(s)",
     "recent": "Recent production"
   },
   "Errors": {

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -450,6 +450,7 @@
     "recording": "Enregistrement…",
     "batchTotal": "{units} articles sur {lines} ligne(s)",
     "success": "{units} articles enregistrés sur {lines} ligne(s).",
+    "waitingOrders": "{orders} commande(s) en attente pour cette taille — {units} article(s)",
     "recent": "Production récente"
   },
   "Errors": {

--- a/src/actions/orders.ts
+++ b/src/actions/orders.ts
@@ -360,3 +360,53 @@ export async function listStaff() {
     .order('full_name');
   return data ?? [];
 }
+
+// ------------------------------------------------- waiting orders (A-FR-9.11)
+
+export type WaitingCount = { orders: number; units: number };
+
+/**
+ * How many outstanding order lines are waiting on each product, so production
+ * entry can say "3 orders waiting for this size" and those garments get set
+ * aside against orders rather than put on the shelf (A-FR-9.11).
+ *
+ * "Waiting" means a line still to be MADE: 'ordered' or 'in_production'. A
+ * 'ready' line is deliberately excluded -- the garment already exists and is
+ * already set aside, so counting it would tell the tailor to put a second one
+ * aside for an order that is satisfied. 'collected' and 'cancelled' are gone.
+ *
+ * Lines with no product_id are free text -- a size the catalogue does not carry,
+ * often exactly why the parent ordered rather than bought -- and cannot be
+ * matched to a product. They are invisible here, which makes every count a
+ * floor rather than a total.
+ *
+ * Aggregated in JS rather than SQL because PostgREST has no GROUP BY, and the
+ * outstanding set for a school uniform shop is small. If it ever isn't, this
+ * becomes a view.
+ */
+export async function listWaitingOrderCounts(): Promise<Record<string, WaitingCount>> {
+  const supabase = await createClient();
+  const { data } = await supabase
+    .from('order_items')
+    .select('product_id, quantity, order_id')
+    .in('status', ['ordered', 'in_production'])
+    .not('product_id', 'is', null);
+
+  const byProduct: Record<string, { orders: Set<string>; units: number }> = {};
+
+  for (const line of data ?? []) {
+    if (!line.product_id) continue;
+    const entry = (byProduct[line.product_id] ??= { orders: new Set(), units: 0 });
+    // A single order can hold several lines of the same product; the order is
+    // still one order, while the garments add up.
+    entry.orders.add(line.order_id);
+    entry.units += line.quantity;
+  }
+
+  return Object.fromEntries(
+    Object.entries(byProduct).map(([productId, entry]) => [
+      productId,
+      { orders: entry.orders.size, units: entry.units }
+    ])
+  );
+}

--- a/src/app/[locale]/(dashboard)/stock/page.tsx
+++ b/src/app/[locale]/(dashboard)/stock/page.tsx
@@ -5,6 +5,7 @@ import {
   listStock,
   listTailorNames
 } from '@/actions/stock';
+import { listWaitingOrderCounts } from '@/actions/orders';
 import { ProductionForm } from '@/components/forms/production-form';
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -30,11 +31,14 @@ export default async function StockPage({ params }: Props) {
   const { locale } = await params;
   setRequestLocale(locale);
 
-  const [products, stock, tailors, recent, t, tProd] = await Promise.all([
+  // Fetched with the page rather than per selection: picking a product then
+  // shows its waiting count instantly instead of waiting on a round trip.
+  const [products, stock, tailors, recent, waiting, t, tProd] = await Promise.all([
     listProducts(),
     listStock(),
     listTailorNames(),
     listRecentProduction(10),
+    listWaitingOrderCounts(),
     getTranslations('Stock'),
     getTranslations('Production')
   ]);
@@ -49,7 +53,7 @@ export default async function StockPage({ params }: Props) {
         <p className="text-sm text-muted-foreground">{tProd('subtitle')}</p>
       </div>
 
-      <ProductionForm products={products} tailors={tailors} />
+      <ProductionForm products={products} tailors={tailors} waiting={waiting} />
 
       {recent.length > 0 ? (
         <Card>

--- a/src/components/forms/production-form.tsx
+++ b/src/components/forms/production-form.tsx
@@ -5,7 +5,7 @@ import { useFieldArray, useForm, useWatch } from 'react-hook-form';
 import { standardSchemaResolver } from '@hookform/resolvers/standard-schema';
 import { useLocale, useTranslations } from 'next-intl';
 import { toast } from 'sonner';
-import { Trash2, Plus, Factory } from 'lucide-react';
+import { Trash2, Plus, Factory, ClipboardList } from 'lucide-react';
 import { useRouter } from '@/i18n/navigation';
 import { recordProductionBatch } from '@/actions/stock';
 import { Button } from '@/components/ui/button';
@@ -20,6 +20,7 @@ import {
   SelectValue
 } from '@/components/ui/select';
 import type { ProductOption } from '@/components/forms/sale-form';
+import type { WaitingCount } from '@/actions/orders';
 import { toDateInputValue } from '@/lib/format';
 import {
   EMPTY_PRODUCTION_LINE,
@@ -43,10 +44,13 @@ import {
 
 export function ProductionForm({
   products,
-  tailors
+  tailors,
+  waiting
 }: {
   products: ProductOption[];
   tailors: string[];
+  /** product_id -> outstanding orders waiting on it (A-FR-9.11). */
+  waiting: Record<string, WaitingCount>;
 }) {
   const t = useTranslations('Production');
   const tSales = useTranslations('Sales');
@@ -133,6 +137,8 @@ export function ProductionForm({
         <CardContent className="space-y-4">
           {fields.map((field, index) => {
             const lineErrors = formState.errors.lines?.[index];
+            const chosen = watchedLines?.[index]?.productId;
+            const waitingHere = chosen ? waiting[chosen] : undefined;
             return (
               <div key={field.id} className="grid gap-3 rounded-lg border p-3 sm:grid-cols-12">
                 <div className="sm:col-span-8">
@@ -158,6 +164,20 @@ export function ProductionForm({
                   {lineErrors?.productId ? (
                     <p className="mt-1 text-xs text-destructive">
                       {message(lineErrors.productId.message)}
+                    </p>
+                  ) : null}
+
+                  {/* Informational only -- it never blocks the entry. Absent
+                      entirely when nothing is waiting, rather than showing a
+                      zero, so it reads as news and not as a permanent label
+                      (A-FR-9.11). */}
+                  {waitingHere ? (
+                    <p className="mt-2 flex items-center gap-1.5 text-xs font-medium text-amber-600 dark:text-amber-500">
+                      <ClipboardList className="size-3.5 shrink-0" />
+                      {t('waitingOrders', {
+                        orders: waitingHere.orders,
+                        units: waitingHere.units
+                      })}
                     </p>
                   ) : null}
                 </div>


### PR DESCRIPTION
Closes #34

Requirement: A-FR-9.11 (SHOULD)

## What this does
When a product is picked on the production form, the screen says how many
outstanding orders are waiting on that exact product and size — so those
garments get set aside against orders instead of going on the shelf and being
sold to a walk-in customer.

Informational only: it never blocks the entry, reserves nothing, changes no stock.

## Decisions worth reviewing
- **`ready` is excluded from "waiting".** Only `ordered` and `in_production`
  count. A `ready` garment already exists and is already set aside — counting it
  would tell the tailor to put a *second* one aside for an order that's satisfied.
- **Both numbers are shown** — "3 order(s) waiting for this size — 7 garment(s)".
  The issue asks for the order count, but garments is what decides how many to
  set aside. Several lines of one product inside one order count as **one order**
  and as **all** of their garments.
- **Counts are fetched with the page**, not per selection, so picking a product
  shows the number instantly rather than after a round trip.
- **Nothing renders when nothing is waiting** — not a zero — so it reads as news
  rather than a permanent label. That's the second acceptance criterion.

## Known limitation
Order lines with no `product_id` are free text (a size the catalogue doesn't
carry — often exactly why the parent ordered rather than bought) and can't be
matched to a product, so every count is a floor rather than a total.

## Testing status — please read
**Not verified end-to-end.** `.env.local` currently has `NEXT_PUBLIC_SUPABASE_URL`
pointing at project `nswxwmsujrcxhbvjmrsl` while the API keys are signed for
`euqcllrnlewmhgsoyflr`, so every API call returns `Invalid API key` and the app
won't run. The aggregation logic was verified in isolation (two lines of one
product in one order → 1 order, 5 garments, not 2 orders).

To verify once the database is connected: create an order for 3 shirts size 10,
leave it at Commandée, go to `/fr/stock` and pick that product — expect
"1 order(s) waiting for this size — 3 garment(s)". Pick a product with no orders
and nothing should appear.