### PR TITLE
fix(db): renumber audit_log_expand so it runs; suppress extension hydration noise

### DIFF
--- a/src/components/dashboard/notification-bell.tsx
+++ b/src/components/dashboard/notification-bell.tsx
@@ -111,6 +111,7 @@ export function NotificationBell() {
                 <p className="text-sm font-semibold">{t('title')}</p>
                 {unread > 0 && (
                   <button
+                    suppressHydrationWarning
                     onClick={onMarkAllRead}
                     className="text-xs font-medium text-primary hover:underline"
                   >
@@ -130,6 +131,7 @@ export function NotificationBell() {
                     const { title, body } = text(n);
                     return (
                       <button
+                        suppressHydrationWarning
                         key={n.id}
                         onClick={() => openItem(n)}
                         className={cn(

--- a/src/components/forms/change-password-form.tsx
+++ b/src/components/forms/change-password-form.tsx
@@ -68,6 +68,7 @@ export function ChangePasswordForm({
       {/* Hidden username field: lets browsers/password managers associate the new
           password with the account, and clears the a11y warning. */}
       <input
+        suppressHydrationWarning
         type="text"
         name="username"
         autoComplete="username"
@@ -91,6 +92,7 @@ export function ChangePasswordForm({
             aria-invalid={Boolean(errors.current)}
           />
           <button
+            suppressHydrationWarning
             type="button"
             onClick={() => setShow((s) => !s)}
             className="absolute right-2 top-1/2 -translate-y-1/2 rounded p-1 text-muted-foreground hover:text-foreground"

--- a/src/components/forms/login-form.tsx
+++ b/src/components/forms/login-form.tsx
@@ -92,6 +92,7 @@ export function LoginForm({ redirectTo }: { redirectTo: string | null }) {
             aria-describedby={state.fieldErrors.password ? 'password-error' : undefined}
           />
           <button
+            suppressHydrationWarning
             type="button"
             onClick={() => setShowPassword((s) => !s)}
             className="absolute right-2 top-1/2 -translate-y-1/2 rounded p-1 text-muted-foreground hover:text-foreground"

--- a/src/components/profile/profile-editor.tsx
+++ b/src/components/profile/profile-editor.tsx
@@ -125,6 +125,7 @@ export function ProfileEditor({
     <div className="rounded-2xl border bg-card p-6 shadow-sm">
       <div className="flex flex-col items-center gap-4 sm:flex-row sm:items-center">
         <button
+          suppressHydrationWarning
           type="button"
           onClick={() => setOpen(true)}
           className="group relative rounded-full outline-none ring-offset-2 ring-offset-card focus-visible:ring-2 focus-visible:ring-ring"
@@ -178,6 +179,7 @@ export function ProfileEditor({
               <Avatar url={avatar} fallback={fallback} className="size-16 text-xl" />
               <div className="flex flex-wrap gap-2">
                 <input
+                  suppressHydrationWarning
                   ref={fileRef}
                   type="file"
                   accept="image/*"

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -41,6 +41,19 @@ const buttonVariants = cva(
   }
 )
 
+/**
+ * suppressHydrationWarning: form-filler browser extensions stamp an
+ * `fdprocessedid` attribute onto every interactive element after the server
+ * HTML arrives but before React hydrates, which React reports as a mismatch on
+ * every input and button on the page. The attribute comes from the visitor's
+ * browser, so no server change can prevent it.
+ *
+ * This suppresses ATTRIBUTE mismatch reporting on this element only -- not its
+ * children, not text content, and not any other element. The cost is real
+ * though narrow: a genuine attribute difference here would also go unreported,
+ * so if this element ever renders differently on server and client, you will
+ * not be told. Do not spread this flag onto containers or layout elements.
+ */
 function Button({
   className,
   variant = "default",
@@ -56,6 +69,7 @@ function Button({
   return (
     <Comp
       data-slot="button"
+      suppressHydrationWarning
       data-variant={variant}
       data-size={size}
       className={cn(buttonVariants({ variant, size, className }))}

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -6,12 +6,26 @@ import { CheckIcon } from 'lucide-react';
 
 import { cn } from '@/lib/utils';
 
+/**
+ * suppressHydrationWarning: form-filler browser extensions stamp an
+ * `fdprocessedid` attribute onto every interactive element after the server
+ * HTML arrives but before React hydrates, which React reports as a mismatch on
+ * every input and button on the page. The attribute comes from the visitor's
+ * browser, so no server change can prevent it.
+ *
+ * This suppresses ATTRIBUTE mismatch reporting on this element only -- not its
+ * children, not text content, and not any other element. The cost is real
+ * though narrow: a genuine attribute difference here would also go unreported,
+ * so if this element ever renders differently on server and client, you will
+ * not be told. Do not spread this flag onto containers or layout elements.
+ */
 function Checkbox({
   className,
   ...props
 }: React.ComponentProps<typeof CheckboxPrimitive.Root>) {
   return (
     <CheckboxPrimitive.Root
+      suppressHydrationWarning
       data-slot="checkbox"
       className={cn(
         'peer size-4 shrink-0 rounded-[4px] border border-input shadow-xs outline-none transition-shadow',

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -2,11 +2,25 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
+/**
+ * suppressHydrationWarning: form-filler browser extensions stamp an
+ * `fdprocessedid` attribute onto every interactive element after the server
+ * HTML arrives but before React hydrates, which React reports as a mismatch on
+ * every input and button on the page. The attribute comes from the visitor's
+ * browser, so no server change can prevent it.
+ *
+ * This suppresses ATTRIBUTE mismatch reporting on this element only -- not its
+ * children, not text content, and not any other element. The cost is real
+ * though narrow: a genuine attribute difference here would also go unreported,
+ * so if this element ever renders differently on server and client, you will
+ * not be told. Do not spread this flag onto containers or layout elements.
+ */
 function Input({ className, type, ...props }: React.ComponentProps<"input">) {
   return (
     <input
       type={type}
       data-slot="input"
+      suppressHydrationWarning
       className={cn(
         "h-8 w-full min-w-0 rounded-lg border border-input bg-transparent px-2.5 py-1 text-base transition-colors outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
         className

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -6,6 +6,19 @@ import { Select as SelectPrimitive } from "radix-ui"
 import { cn } from "@/lib/utils"
 import { ChevronDownIcon, CheckIcon, ChevronUpIcon } from "lucide-react"
 
+/**
+ * suppressHydrationWarning: form-filler browser extensions stamp an
+ * `fdprocessedid` attribute onto every interactive element after the server
+ * HTML arrives but before React hydrates, which React reports as a mismatch on
+ * every input and button on the page. The attribute comes from the visitor's
+ * browser, so no server change can prevent it.
+ *
+ * This suppresses ATTRIBUTE mismatch reporting on this element only -- not its
+ * children, not text content, and not any other element. The cost is real
+ * though narrow: a genuine attribute difference here would also go unreported,
+ * so if this element ever renders differently on server and client, you will
+ * not be told. Do not spread this flag onto containers or layout elements.
+ */
 function Select({
   ...props
 }: React.ComponentProps<typeof SelectPrimitive.Root>) {
@@ -42,6 +55,7 @@ function SelectTrigger({
   return (
     <SelectPrimitive.Trigger
       data-slot="select-trigger"
+      suppressHydrationWarning
       data-size={size}
       className={cn(
         "flex w-fit items-center justify-between gap-1.5 rounded-lg border border-input bg-transparent py-2 pr-2 pl-2.5 text-sm whitespace-nowrap transition-colors outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 data-placeholder:text-muted-foreground data-[size=default]:h-8 data-[size=sm]:h-7 data-[size=sm]:rounded-[min(var(--radius-md),10px)] *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-1.5 dark:bg-input/30 dark:hover:bg-input/50 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,10 +2,24 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
+/**
+ * suppressHydrationWarning: form-filler browser extensions stamp an
+ * `fdprocessedid` attribute onto every interactive element after the server
+ * HTML arrives but before React hydrates, which React reports as a mismatch on
+ * every input and button on the page. The attribute comes from the visitor's
+ * browser, so no server change can prevent it.
+ *
+ * This suppresses ATTRIBUTE mismatch reporting on this element only -- not its
+ * children, not text content, and not any other element. The cost is real
+ * though narrow: a genuine attribute difference here would also go unreported,
+ * so if this element ever renders differently on server and client, you will
+ * not be told. Do not spread this flag onto containers or layout elements.
+ */
 function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
   return (
     <textarea
       data-slot="textarea"
+      suppressHydrationWarning
       className={cn(
         "field-sizing-content min-h-16 w-full min-w-0 rounded-lg border border-input bg-transparent px-2.5 py-1.5 text-base transition-colors outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
         className

--- a/supabase/migrations/20260101001500_audit_log_expand.sql
+++ b/supabase/migrations/20260101001500_audit_log_expand.sql
@@ -1,3 +1,16 @@
+-- Renumbered from 20260101000800.
+--
+-- That version was already taken by 20260101000800_orders.sql, which had been
+-- applied first. The Supabase CLI keys migrations by the numeric prefix, so it
+-- saw 20260101000800 as done and skipped this file -- silently. None of the
+-- columns below existed in the database, logAudit() swallows its own errors by
+-- design, and so every application-level audit write failed without a sound
+-- while the audit viewer's query failed outright.
+--
+-- Nothing here changed but the file name. Every statement is idempotent
+-- (add column if not exists / create or replace / drop ... if exists), so it is
+-- safe on a database that somehow did get the original.
+
 -- Audit log expansion (spec A-11 / A-FR-11.2, A-FR-11.3, A-FR-11.4).
 --
 -- The first cut of audit_log carried only login events (actor_id, action, ip,

--- a/supabase/migrations/rollback/20260101001500_audit_log_expand_down.sql
+++ b/supabase/migrations/rollback/20260101001500_audit_log_expand_down.sql
@@ -1,4 +1,4 @@
--- Rollback of 20260101000800_audit_log_expand.sql. Manual (see the header in
+-- Rollback of 20260101001500_audit_log_expand.sql. Manual (see the header in
 -- rollback/20260101000000_init_down.sql).
 
 drop trigger if exists audit_log_no_update on public.audit_log;


### PR DESCRIPTION
Two unrelated fixes. The first is the urgent one.

## 1. `audit_log_expand` was never applied — silently

`supabase/migrations/20260101000800_audit_log_expand.sql` shared its version
number with `20260101000800_orders.sql`, which had already been applied. The
Supabase CLI keys migrations by their numeric prefix, so it saw `20260101000800`
as done and skipped the audit expansion — with no error, because from the CLI's
point of view there was nothing left to do.

The consequence was quiet and bad. None of `actor_name`, `target_table`,
`target_id`, `previous_value` or `new_value` existed in the database, while
`logAudit()` wrote all five and the audit viewer selected all five.
`logAudit()` swallows its own errors on purpose — auditing must not break the
request it is recording — so **every application-level audit write failed in
silence**, and the viewer's query failed outright. An audit trail that stops
recording without saying so is worse than one that is obviously broken.

Verified against the live database before the fix: all five columns missing.

**The fix is the file name only.** Renamed to `20260101001500_audit_log_expand.sql`
(and its rollback to match); not a line of SQL changed. Every statement in it was
already idempotent — `add column if not exists`, `create or replace function`,
`drop trigger if exists` — so it is safe on a database that somehow did receive
the original.

Database-level audit rows were never affected. `enforce_order_line_transition()`
writes `audit_log` in raw SQL using only the original columns, so order status
transitions kept being recorded throughout.

### This is the third collision
`20260101000700` collided too (orders vs `active_user_count`), and was fixed the
same way. All three came from timestamps being picked by hand from the same
starting point on parallel branches. Git can't catch it — two differently-named
files merge cleanly — and the CLI reports success while skipping one. Two things
would stop a fourth:
- `npx supabase migration new <name>` to generate the timestamp instead of typing it
- a CI check failing any PR where two migrations share a version prefix

Happy to add the CI check as a follow-up.

## 2. Form-filler extensions reported as hydration mismatches

Form-filler browser extensions stamp an `fdprocessedid` attribute onto every
interactive element after the server HTML arrives but before React hydrates.
React reports that as a mismatch on every input and button on the page. The
attribute originates in the visitor's browser, so no server-side change prevents it.

`suppressHydrationWarning` is applied to the interactive primitives only — input,
textarea, button, select trigger, checkbox — plus the handful of raw buttons and
inputs that don't go through 