### PR TITLE
fix(db): restore the six-digit reference format the repo defines

### DIFF
--- a/supabase/migrations/20260101001800_reference_format.sql
+++ b/supabase/migrations/20260101001800_reference_format.sql
@@ -1,0 +1,38 @@
+-- Restore the reference format the repo defines.
+--
+-- 20260101000800 defines next_reference() with lpad(..., 6, '0'), and every
+-- reference already issued follows it: ORD-2026-000001, R-2026-000001. The
+-- function deployed to this database pads to 4 instead, so the next order would
+-- have been ORD-2026-0002 -- the same column holding two formats that sort
+-- wrongly against each other.
+--
+-- The drift came from the schema being created by hand rather than by these
+-- migrations, which is also why the migration history was empty until it was
+-- repaired. A history repair can only check that a migration's tables exist; it
+-- cannot see that a function inside one was altered afterwards.
+--
+-- Nothing here is new. The body below is copied verbatim from 20260101000800,
+-- re-asserted with create or replace so a database that drifted comes back into
+-- line and one that never did is unaffected. References already issued keep
+-- whatever they have; only newly generated ones change.
+
+create or replace function public.next_reference(p_prefix text)
+returns text
+language plpgsql
+volatile
+security definer
+set search_path = public, pg_temp
+as $fn$
+declare
+  v_year integer := extract(year from now())::integer;
+  v_next bigint;
+begin
+  insert into public.reference_counters as rc (prefix, year, last_value)
+  values (p_prefix, v_year, 1)
+  on conflict (prefix, year)
+    do update set last_value = rc.last_value + 1
+  returning rc.last_value into v_next;
+
+  return p_prefix || '-' || v_year::text || '-' || lpad(v_next::text, 6, '0');
+end;
+$fn$;

--- a/supabase/migrations/rollback/20260101001800_reference_format_down.sql
+++ b/supabase/migrations/rollback/20260101001800_reference_format_down.sql
@@ -1,0 +1,10 @@
+-- Rollback for 20260101001800_reference_format.sql.
+--
+-- MANUAL ONLY -- see supabase/README.md.
+--
+-- Deliberately a no-op. This migration only restores the function body that
+-- 20260101000800 already defines, so "undoing" it would mean deliberately
+-- reintroducing a padding width that disagrees with every reference already
+-- issued. If you genuinely want a different width, change it in one place --
+-- 20260101000800 -- and add a forward migration re-asserting that, rather than
+-- rolling this back.


### PR DESCRIPTION
20260101000800 defines next_reference() with lpad(..., 6, '0'), and every reference already issued follows it: ORD-2026-000001, R-2026-000001. The function deployed to the database padded to 4 instead, so the next order would have come out as ORD-2026-0002 -- one column holding two formats that sort wrongly against each other, and contradicting the six-digit width chosen when orders were specified.

The drift came from the schema being created by hand rather than by these migrations, which is also why the migration history was empty until it was repaired. Worth noting the limit that exposes: a history repair can only check that a migration's tables exist. It cannot see that a function inside one was altered afterwards, so "applied" meant the table matched while the function did not.

Nothing here is new. The body is copied verbatim from 20260101000800 and re-asserted with create or replace, so a database that drifted comes back into line and one that never did is unaffected. References already issued keep whatever they have; only newly generated ones change.

Verified after applying: next_reference('ZZFMT') returns ZZFMT-2026-000001 then ZZFMT-2026-000002.