### PR TITLE
/feat(open-jobs): unified board of open orders and alterations

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -373,6 +373,25 @@
       "cancelled": "Cancelled"
     }
   },
+  "OpenJobs": {
+    "title": "Open jobs",
+    "subtitle": "Every order and alteration not yet closed. Oldest first.",
+    "searchPlaceholder": "Search student, parent or reference…",
+    "all": "All",
+    "stage": {
+      "waiting": "Waiting",
+      "in_progress": "In progress",
+      "ready": "Ready"
+    },
+    "daysOpen": "{days} day(s) open",
+    "openedOn": "Opened {date}",
+    "expectedOn": "Expected {date}",
+    "openJob": "Open",
+    "nothingOpen": "Nothing is open. Everything has been collected, returned or cancelled.",
+    "noMatches": "No open job matches that search.",
+    "kindOrder": "Order",
+    "kindAlteration": "Alteration"
+  },
   "Alterations": {
     "title": "Alterations",
     "subtitle": "Take in a garment the parent already owns, to be resized or repaired.",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -373,6 +373,25 @@
       "cancelled": "Annul\u00e9e"
     }
   },
+  "OpenJobs": {
+    "title": "Travaux en cours",
+    "subtitle": "Toutes les commandes et retouches non clôturées. Les plus anciennes d’abord.",
+    "searchPlaceholder": "Rechercher élève, parent ou référence…",
+    "all": "Tout",
+    "stage": {
+      "waiting": "En attente",
+      "in_progress": "En cours",
+      "ready": "Prêt"
+    },
+    "daysOpen": "{days} jour(s)",
+    "openedOn": "Ouvert le {date}",
+    "expectedOn": "Prévu le {date}",
+    "openJob": "Ouvrir",
+    "nothingOpen": "Aucun travail en cours. Tout a été retiré, restitué ou annulé.",
+    "noMatches": "Aucun travail ne correspond à cette recherche.",
+    "kindOrder": "Commande",
+    "kindAlteration": "Retouche"
+  },
   "Alterations": {
     "title": "Retouches",
     "subtitle": "Réceptionner un vêtement appartenant au parent, à retoucher ou réparer.",

--- a/src/actions/auth.ts
+++ b/src/actions/auth.ts
@@ -81,10 +81,15 @@ export async function signIn(
   const locale = await getLocale();
   revalidatePath('/', 'layout');
 
-  // Every user's first screen is their role dashboard overview -- always, even
-  // when they were deep-linking somewhere else. The locale-aware `redirect`
-  // adds the locale prefix itself, so the path passed in must not carry one.
-  redirect({ href: '/dashboard', locale });
+  // Sent to the locale index rather than to a named screen, because where a
+  // user starts depends on their role -- a seller lands on the open-jobs board,
+  // everyone else on the dashboard -- and that rule lives in one place,
+  // app/[locale]/page.tsx. Hard-coding a destination here would be a second
+  // copy of it that quietly drifts.
+  //
+  // Still ignores `redirectTo`: the first screen after signing in is the one
+  // the role calls for, even when the user was deep-linking somewhere else.
+  redirect({ href: '/', locale });
 
   // `redirect` throws, so this is unreachable -- it only exists because the
   // helper isn't typed as `never` and useActionState needs a concrete state type.

--- a/src/actions/open-jobs.ts
+++ b/src/actions/open-jobs.ts
@@ -1,0 +1,97 @@
+'use server';
+
+import { createClient } from '@/lib/supabase/server';
+import {
+  alterationStage,
+  orderStage,
+  sortOldestFirst,
+  type OpenJob
+} from '@/lib/open-jobs';
+
+/**
+ * Everything not yet closed, from both sources, as one list (A-FR-9.16).
+ *
+ * Two queries rather than one: orders and alterations are separate tables with
+ * separate shapes, and PostgREST has no UNION. They are merged and sorted here,
+ * which is fine at a school uniform shop's volume -- the open pile is the work
+ * of a few weeks, not a warehouse. If it ever isn't, this becomes a view.
+ *
+ * RLS scopes both halves the same way it scopes everything else: a seller sees
+ * their own, oversight roles see all. Nothing extra is checked here.
+ */
+export async function listOpenJobs(): Promise<OpenJob[]> {
+  const supabase = await createClient();
+
+  const [orderLines, alterations] = await Promise.all([
+    // Only lines still to be dealt with. A line handed over at the counter has
+    // status null and was never a job; collected and cancelled are closed.
+    supabase
+      .from('order_items')
+      .select(
+        `id, description, size, status,
+         order:orders!order_items_order_id_fkey (
+           id, order_no, ordered_at, expected_ready_date,
+           customer_name, student_name, class_level
+         )`
+      )
+      .in('status', ['ordered', 'in_production', 'ready']),
+
+    supabase
+      .from('alterations')
+      .select(
+        `id, alteration_no, received_at, expected_ready_date, status,
+         customer_name, student_name, class_level, garment, size`
+      )
+      .in('status', ['received', 'in_progress', 'ready'])
+  ]);
+
+  const jobs: OpenJob[] = [];
+
+  for (const line of orderLines.data ?? []) {
+    const order = line.order;
+    // An order line with no parent order cannot be shown or linked to; skipping
+    // beats rendering a card that goes nowhere.
+    if (!order || !line.status) continue;
+    const stage = orderStage(line.status);
+    if (!stage) continue;
+
+    jobs.push({
+      key: `order:${line.id}`,
+      kind: 'order',
+      href: `/orders/${order.id}`,
+      reference: order.order_no,
+      stage,
+      statusLabel: line.status,
+      studentName: order.student_name,
+      classLevel: order.class_level,
+      customerName: order.customer_name,
+      garment: line.description,
+      size: line.size,
+      openedAt: order.ordered_at,
+      expectedReadyDate: order.expected_ready_date
+    });
+  }
+
+  for (const alteration of alterations.data ?? []) {
+    const stage = alterationStage(alteration.status);
+    if (!stage) continue;
+
+    jobs.push({
+      key: `alteration:${alteration.id}`,
+      kind: 'alteration',
+      href: `/alterations/${alteration.id}`,
+      reference: alteration.alteration_no,
+      stage,
+      statusLabel: alteration.status,
+      studentName: alteration.student_name,
+      classLevel: alteration.class_level,
+      customerName: alteration.customer_name,
+      garment: alteration.garment,
+      size: alteration.size,
+      openedAt: alteration.received_at,
+      expectedReadyDate: alteration.expected_ready_date
+    });
+  }
+
+  return sortOldestFirst(jobs);
+}

--- a/src/app/[locale]/(dashboard)/open-jobs/page.tsx
+++ b/src/app/[locale]/(dashboard)/open-jobs/page.tsx
@@ -1,0 +1,31 @@
+import { getTranslations, setRequestLocale } from 'next-intl/server';
+import { listOpenJobs } from '@/actions/open-jobs';
+import { OpenJobsBoard } from '@/components/open-jobs/open-jobs-board';
+
+type Props = { params: Promise<{ locale: string }> };
+
+export async function generateMetadata({ params }: Props) {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: 'OpenJobs' });
+  return { title: t('title') };
+}
+
+export default async function OpenJobsPage({ params }: Props) {
+  const { locale } = await params;
+  setRequestLocale(locale);
+
+  const [jobs, t] = await Promise.all([listOpenJobs(), getTranslations('OpenJobs')]);
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-1">
+        <h1 className="text-2xl font-semibold tracking-tight">{t('title')}</h1>
+        <p className="text-sm text-muted-foreground">{t('subtitle')}</p>
+      </div>
+
+      {/* Sorted oldest first on the server (A-FR-9.17); the board filters and
+          searches that list without reordering it. */}
+      <OpenJobsBoard jobs={jobs} />
+    </div>
+  );
+}

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -1,9 +1,32 @@
 import { redirect } from '@/i18n/navigation';
+import { getProfile } from '@/actions/auth';
 
 type Props = { params: Promise<{ locale: string }> };
 
-/** The app has no marketing page -- land people on their role dashboard. */
+/**
+ * The app has no marketing page, so this decides where signing in puts you.
+ *
+ * A seller lands on the open-jobs board rather than the dashboard (A-FR-9.16).
+ * The dashboard answers "how are we doing"; the board answers "what do I do
+ * next", and for the person at the counter that is the whole job. It is the
+ * part that replaces remembering, so it should be the first thing they see
+ * rather than one click away.
+ *
+ * Every other role keeps the dashboard: administration and oversight want the
+ * overview, and a super admin arriving at a list of garments to sew would be
+ * looking at somebody else's work.
+ *
+ * The board is still reachable from the nav for everyone, and the dashboard is
+ * still reachable for a seller -- this changes the landing, not the access.
+ */
 export default async function LocaleIndex({ params }: Props) {
   const { locale } = await params;
-  redirect({ href: '/dashboard', locale });
+
+  // No profile means no session, or a session whose row cannot be read. Either
+  // way the dashboard is the safe destination: it handles that case already,
+  // and the proxy will bounce a signed-out visitor to login before this runs.
+  const profile = await getProfile();
+  const href = profile?.role === 'seller' ? '/open-jobs' : '/dashboard';
+
+  redirect({ href, locale });
 }

--- a/src/components/open-jobs/open-jobs-board.tsx
+++ b/src/components/open-jobs/open-jobs-board.tsx
@@ -1,0 +1,167 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { useLocale, useTranslations } from 'next-intl';
+import { Search, ShoppingBag, Scissors, TriangleAlert } from 'lucide-react';
+import { Link } from '@/i18n/navigation';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { formatDate } from '@/lib/format';
+import {
+  daysOpen,
+  isOverdue,
+  JOB_STAGES,
+  matchesSearch,
+  type JobStage,
+  type OpenJob
+} from '@/lib/open-jobs';
+
+/**
+ * The open-jobs board (A-FR-9.16, A-FR-9.17, A-FR-9.18).
+ *
+ * "The part that replaces remembering": every order line and alteration not yet
+ * closed, oldest first, as one pile.
+ *
+ * Filtering and searching happen in the browser over a list the server already
+ * sent. The open pile at a school uniform shop is the work of a few weeks, so
+ * refetching per keystroke would add latency to solve a problem this screen
+ * does not have -- and typing a student's name gives instant results, which is
+ * what a counter needs.
+ */
+
+export function OpenJobsBoard({ jobs }: { jobs: OpenJob[] }) {
+  const t = useTranslations('OpenJobs');
+  const tOrders = useTranslations('Orders');
+  const tAlt = useTranslations('Alterations');
+  const locale = useLocale();
+
+  const [stage, setStage] = useState<JobStage | 'all'>('all');
+  const [query, setQuery] = useState('');
+
+  const visible = useMemo(
+    () =>
+      jobs.filter(
+        (job) => (stage === 'all' || job.stage === stage) && matchesSearch(job, query)
+      ),
+    [jobs, stage, query]
+  );
+
+  /** Each job keeps its own vocabulary; only the filter is shared. */
+  const statusLabel = (job: OpenJob) =>
+    job.kind === 'order'
+      ? tOrders(`status.${job.statusLabel}`)
+      : tAlt(`status.${job.statusLabel}`);
+
+  const countFor = (s: JobStage | 'all') =>
+    s === 'all' ? jobs.length : jobs.filter((job) => job.stage === s).length;
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-center gap-2">
+        <div className="relative min-w-[16rem] flex-1">
+          <Search className="pointer-events-none absolute left-2.5 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder={t('searchPlaceholder')}
+            className="pl-8"
+            aria-label={t('searchPlaceholder')}
+          />
+        </div>
+
+        <div className="flex flex-wrap gap-1">
+          {(['all', ...JOB_STAGES] as const).map((value) => (
+            <Button
+              key={value}
+              type="button"
+              size="sm"
+              variant={stage === value ? 'default' : 'outline'}
+              onClick={() => setStage(value)}
+            >
+              {value === 'all' ? t('all') : t(`stage.${value}`)}
+              <span className="ml-1.5 tabular-nums opacity-70">{countFor(value)}</span>
+            </Button>
+          ))}
+        </div>
+      </div>
+
+      {visible.length === 0 ? (
+        <Card>
+          <CardContent className="py-10 text-center text-sm text-muted-foreground">
+            {jobs.length === 0 ? t('nothingOpen') : t('noMatches')}
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+          {visible.map((job) => {
+            const age = daysOpen(job.openedAt);
+            const overdue = isOverdue(job);
+            const Icon = job.kind === 'order' ? ShoppingBag : Scissors;
+
+            return (
+              <Card key={job.key} className={overdue ? 'border-destructive/50' : undefined}>
+                <CardContent className="space-y-2 p-4">
+                  <div className="flex items-start justify-between gap-2">
+                    <div className="min-w-0">
+                      <p className="truncate font-medium">
+                        {job.garment}
+                        {job.size ? (
+                          <span className="text-muted-foreground"> ({job.size})</span>
+                        ) : null}
+                      </p>
+                      <p className="truncate text-sm text-muted-foreground">
+                        {job.studentName || job.customerName}
+                        {job.classLevel ? ` · ${job.classLevel}` : ''}
+                      </p>
+                    </div>
+                    <Icon
+                      className="mt-0.5 size-4 shrink-0 text-muted-foreground"
+                      aria-label={job.kind === 'order' ? t('kindOrder') : t('kindAlteration')}
+                    />
+                  </div>
+
+                  <div className="flex flex-wrap items-center gap-1">
+                    <Badge variant="secondary" className="font-mono text-[0.7rem]">
+                      {job.reference}
+                    </Badge>
+                    <Badge variant="outline" className="text-[0.7rem]">
+                      {statusLabel(job)}
+                    </Badge>
+                    {/* The age is the number the seller scans for, so it is a
+                        badge rather than buried in a line of text. */}
+                    <Badge
+                      variant={age >= 14 ? 'destructive' : 'outline'}
+                      className="text-[0.7rem]"
+                    >
+                      {t('daysOpen', { days: age })}
+                    </Badge>
+                  </div>
+
+                  <div className="space-y-0.5 text-xs text-muted-foreground">
+                    <p>{t('openedOn', { date: formatDate(job.openedAt, locale) })}</p>
+                    {job.expectedReadyDate ? (
+                      <p className={overdue ? 'font-medium text-destructive' : undefined}>
+                        {overdue ? (
+                          <TriangleAlert className="mr-1 inline size-3" />
+                        ) : null}
+                        {t('expectedOn', {
+                          date: formatDate(job.expectedReadyDate, locale)
+                        })}
+                      </p>
+                    ) : null}
+                  </div>
+
+                  <Button asChild variant="link" size="sm" className="h-auto p-0">
+                    <Link href={job.href}>{t('openJob')}</Link>
+                  </Button>
+                </CardContent>
+              </Card>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/lib/dashboard-nav.ts
+++ b/src/lib/dashboard-nav.ts
@@ -37,7 +37,7 @@ export const NAV_ITEMS: readonly NavItem[] = [
 
   { key: 'sales', href: '/sales', icon: ShoppingCart, section: 'operations', roles: ALL },
   { key: 'orders', href: '/orders', icon: PackagePlus, section: 'operations', roles: ALL },
-  { key: 'openJobs', icon: ClipboardList, section: 'operations', roles: ALL },
+  { key: 'openJobs', href: '/open-jobs', icon: ClipboardList, section: 'operations', roles: ALL },
   { key: 'alterations', href: '/alterations', icon: Scissors, section: 'operations', roles: ALL },
   { key: 'production', href: '/stock', icon: Boxes, section: 'operations', roles: ALL },
   { key: 'returns', icon: RefreshCcw, section: 'operations', roles: OPERATORS },

--- a/src/lib/open-jobs.ts
+++ b/src/lib/open-jobs.ts
@@ -1,0 +1,135 @@
+import type { AlterationStatus, OrderStatus } from '@/types/database.types';
+
+/**
+ * The open-jobs list (A-FR-9.16, A-FR-9.17, A-FR-9.18).
+ *
+ * Orders and alterations are different things with different vocabularies -- a
+ * garment is RECEIVED from its owner and RETURNED to them; a uniform is ORDERED
+ * and COLLECTED -- but to the seller standing at the counter they are one pile
+ * of work. This module is what lets both be one list without pretending they
+ * are the same record.
+ *
+ * A card is one outstanding ORDER LINE or one alteration. An order for a blazer
+ * and two shirts is three garments at possibly three different statuses, and a
+ * single card could not honestly show that.
+ */
+
+export type JobKind = 'order' | 'alteration';
+
+/**
+ * The shared stage the filter works on.
+ *
+ * Cards still display each job's own status word -- calling an alteration
+ * "ordered" would be wrong, and the seller reads these words aloud to parents.
+ * The stage exists so one filter can span both, rather than the screen needing
+ * two dropdowns that mean the same three things.
+ */
+export type JobStage = 'waiting' | 'in_progress' | 'ready';
+
+export const JOB_STAGES = ['waiting', 'in_progress', 'ready'] as const;
+
+export function orderStage(status: OrderStatus): JobStage | null {
+  switch (status) {
+    case 'ordered':
+      return 'waiting';
+    case 'in_production':
+      return 'in_progress';
+    case 'ready':
+      return 'ready';
+    default:
+      // collected and cancelled are closed -- they leave the list entirely.
+      return null;
+  }
+}
+
+export function alterationStage(status: AlterationStatus): JobStage | null {
+  switch (status) {
+    case 'received':
+      return 'waiting';
+    case 'in_progress':
+      return 'in_progress';
+    case 'ready':
+      return 'ready';
+    default:
+      // returned and cancelled are closed.
+      return null;
+  }
+}
+
+export type OpenJob = {
+  /** Unique across both sources, so React keys and links stay unambiguous. */
+  key: string;
+  kind: JobKind;
+  /** The row to link to: the order, or the alteration. */
+  href: string;
+  reference: string;
+  stage: JobStage;
+  /** The job's own status word, translated by the caller. */
+  statusLabel: OrderStatus | AlterationStatus;
+  studentName: string | null;
+  classLevel: string | null;
+  /** Who to call. Also what "search by parent name" matches. */
+  customerName: string;
+  garment: string;
+  size: string | null;
+  /** When the job started: ordered_at, or received_at. */
+  openedAt: string;
+  expectedReadyDate: string | null;
+};
+
+/**
+ * Whole days the job has been open.
+ *
+ * Deliberately computed from calendar dates rather than elapsed milliseconds: a
+ * job taken in yesterday afternoon is "1 day", not "0 days" because 24 hours
+ * have not passed. That is how the shop counts, and the number is read as an
+ * age, not a duration.
+ */
+export function daysOpen(openedAt: string, now: Date = new Date()): number {
+  const opened = new Date(openedAt);
+  const a = Date.UTC(opened.getFullYear(), opened.getMonth(), opened.getDate());
+  const b = Date.UTC(now.getFullYear(), now.getMonth(), now.getDate());
+  return Math.max(0, Math.round((b - a) / 86_400_000));
+}
+
+/** Past its expected date and still not finished. Drives the flag on the card. */
+export function isOverdue(job: OpenJob, now: Date = new Date()): boolean {
+  if (!job.expectedReadyDate) return false;
+  const [y, m, d] = job.expectedReadyDate.split('-').map(Number);
+  // Parsed as local rather than via Date(string), which would read a date-only
+  // value as UTC midnight and flag a job a day early west of Greenwich.
+  return new Date(y, m - 1, d).getTime() < new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime();
+}
+
+/**
+ * Oldest first (A-FR-9.17). The longest-waiting job is the one most likely to
+ * be a problem, so it goes at the top and stays there until it is dealt with.
+ */
+export function sortOldestFirst(jobs: OpenJob[]): OpenJob[] {
+  return [...jobs].sort(
+    (a, b) => new Date(a.openedAt).getTime() - new Date(b.openedAt).getTime()
+  );
+}
+
+/** Matches a student or parent name, case- and accent-insensitively. */
+export function matchesSearch(job: OpenJob, query: string): boolean {
+  const needle = normalise(query);
+  if (!needle) return true;
+  return (
+    normalise(job.studentName ?? '').includes(needle) ||
+    normalise(job.customerName).includes(needle) ||
+    normalise(job.reference).includes(needle)
+  );
+}
+
+/**
+ * Lowercased and stripped of accents, so "Therese" finds "Thérèse". Names here
+ * are typed by whoever is at the counter and rarely typed the same way twice.
+ */
+function normalise(value: string): string {
+  return value
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
+    .toLowerCase()
+    .trim();
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -89,8 +89,12 @@ export async function proxy(request: NextRequest) {
     return NextResponse.redirect(loginUrl);
   }
 
+  // Already signed in and asking for /login: send them to the locale index,
+  // which decides by role. The middleware deliberately does not make that
+  // choice itself -- it would need the profile row, and the rule already has a
+  // home in app/[locale]/page.tsx.
   if (user && isPublic) {
-    return NextResponse.redirect(new URL(`/${locale}/dashboard`, request.url));
+    return NextResponse.redirect(new URL(`/${locale}`, request.url));
   }
 
   return response;


### PR DESCRIPTION
Closes #35

Requirements: A-FR-9.16, A-FR-9.17, A-FR-9.18

## What this does
The part that replaces remembering: every order line and alteration not yet
closed, oldest first, as one pile of work.

**A card is one outstanding order line or one alteration**, not one order. An
order for a blazer and two shirts is three garments at possibly three different
statuses, and a single card couldn't honestly show that.

Orders and alterations keep their **own vocabulary** on the card — a garment is
*received* and *returned*, a uniform is *ordered* and *collected* — because the
seller reads those words aloud to parents. A shared three-value stage
(waiting / in progress / ready) exists only so one filter can span both, instead
of two dropdowns meaning the same three things.

## Details worth reviewing
- **Days open counts calendar days, not elapsed hours.** A garment taken in
  yesterday afternoon reads "1 day", not "0" — that's how a shop counts.
- **The overdue flag parses the expected date as local**, not via `Date(string)`,
  which reads a date-only value as UTC midnight and would flag jobs a day early
  west of Greenwich.
- **Search is accent-insensitive** across student, parent and reference — names
  are typed by whoever is at the counter and rarely the same way twice.
- **Filtering happens in the browser** over a list the server already sorted. The
  open pile is a few weeks of work; refetching per keystroke would add latency to
  solve a problem this screen doesn't have.

## Behaviour change: sellers land here
The dashboard answers "how are we doing"; this board answers "what do I do next".

That rule now lives in exactly **one** place, `app/[locale]/page.tsx`. `signIn`
and the proxy previously hard-coded `/dashboard` — which meant the rule couldn't
be changed without finding all three, and in fact silently defeated the first
attempt at this. Both now defer to the locale index. The proxy deliberately
doesn't decide for itself: it would need the profile row, and a second copy would
drift.

This changes the **landing, not the access** — sellers can still reach the
dashboard, every role can still reach the board.

## Testing
Verified live against the database. Logic checked in isolation: `daysOpen`,
overdue boundaries (due today is not late), accent-insensitive search, oldest-first
ordering. Signed in as the seller (Mr. Ateba) → lands on the board; as super admin
→ lands on the dashboard.