### PR TITLE
PR/feat(receipts): reprints stamped DUPLICATA / DUPLICATE and audited

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -540,6 +540,7 @@
     "paymentMethod": "Paid by",
     "signature": "Signature",
     "footer": "Thank you for your purchase. Goods sold are exchangeable within 7 days with this receipt.",
+    "reprint": "Reprint",
     "print": "Print receipt",
     "back": "Back to sales"
   },

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -540,6 +540,7 @@
     "paymentMethod": "R\u00e9gl\u00e9 par",
     "signature": "Signature",
     "footer": "Merci de votre achat. Les articles vendus sont \u00e9changeables sous 7 jours avec ce re\u00e7u.",
+    "reprint": "Réimprimer",
     "print": "Imprimer le re\u00e7u",
     "back": "Retour aux ventes"
   },

--- a/src/actions/reprints.ts
+++ b/src/actions/reprints.ts
@@ -1,0 +1,75 @@
+'use server';
+
+import { createClient } from '@/lib/supabase/server';
+import { logAudit } from '@/lib/audit';
+
+/**
+ * Recording that a document was reprinted (A-FR-7.12).
+ *
+ * Every reprint is logged with who and when. That is the half of the
+ * requirement the stamp cannot cover: the stamp warns whoever is holding the
+ * paper, while the log is what answers "how many copies of this receipt exist,
+ * and who asked for them" weeks later.
+ *
+ * Called as the reprint page renders rather than when Print is clicked, so a
+ * reprint is recorded even if the operator uses the browser's own print
+ * command or simply photographs the screen. The consequence is that reloading
+ * the page logs again -- which is honest: each render produced another
+ * duplicate on screen, and an audit trail that under-reports is worse than one
+ * that repeats.
+ */
+export type ReprintKind = 'sale' | 'order' | 'collection' | 'alteration';
+
+const TARGET_TABLE: Record<ReprintKind, string> = {
+  sale: 'sales',
+  order: 'orders',
+  collection: 'collections',
+  alteration: 'alterations'
+};
+
+export async function logReprint(params: {
+  kind: ReprintKind;
+  id: string;
+  /** The document's own number -- R-, ORD-, COL- or ALT- -- for readability. */
+  reference: string;
+}): Promise<void> {
+  const supabase = await createClient();
+  const {
+    data: { user }
+  } = await supabase.auth.getUser();
+  if (!user) return;
+
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('full_name')
+    .eq('id', user.id)
+    .single();
+
+  // Never throws: logAudit swallows its own errors, because failing to record a
+  // reprint must not stop the operator handing a parent their paperwork.
+  await logAudit({
+    actorId: user.id,
+    actorName: profile?.full_name ?? user.email ?? null,
+    action: 'document_reprinted',
+    entity: params.reference,
+    targetTable: TARGET_TABLE[params.kind],
+    targetId: params.id,
+    meta: { kind: params.kind, reference: params.reference }
+  });
+}
+
+/**
+ * Whether this render is a reprint.
+ *
+ * A URL flag, by decision: the "Reprint" button on a record links here, and the
+ * plain document URL stays the original. Worth knowing the limit -- trimming
+ * `?reprint=1` yields an unstamped copy, so the stamp deters rather than
+ * prevents. Closing that would mean recording on the record itself whether it
+ * had ever been printed.
+ */
+export async function isReprintRequest(
+  searchParams: Promise<{ reprint?: string }>
+): Promise<boolean> {
+  const { reprint } = await searchParams;
+  return reprint === '1';
+}

--- a/src/app/[locale]/(dashboard)/alterations/[id]/slip/page.tsx
+++ b/src/app/[locale]/(dashboard)/alterations/[id]/slip/page.tsx
@@ -1,9 +1,14 @@
+import { isReprintRequest, logReprint } from '@/actions/reprints';
 import { notFound } from 'next/navigation';
 import { getTranslations, setRequestLocale } from 'next-intl/server';
 import { getAlteration } from '@/actions/alterations';
 import { DepositSlip, type DepositSlipData } from '@/components/receipt/deposit-slip';
 
-type Props = { params: Promise<{ locale: string; id: string }> };
+type Props = {
+  params: Promise<{ locale: string; id: string }>;
+  /** `?reprint=1` marks the sheet DUPLICATA / DUPLICATE and logs it. */
+  searchParams: Promise<{ reprint?: string }>;
+};
 
 export async function generateMetadata({ params }: Props) {
   const { locale, id } = await params;
@@ -14,14 +19,22 @@ export async function generateMetadata({ params }: Props) {
   };
 }
 
-export default async function DepositSlipPage({ params }: Props) {
+export default async function DepositSlipPage({ params, searchParams }: Props) {
   const { locale, id } = await params;
   setRequestLocale(locale);
 
   const alteration = await getAlteration(id);
   if (!alteration) notFound();
 
+
+  // A reprint is stamped and recorded; the plain URL stays the original
+  // (A-FR-7.12).
+  const duplicate = await isReprintRequest(searchParams);
+  if (duplicate) {
+    await logReprint({ kind: 'alteration', id: alteration.id, reference: alteration.alteration_no });
+  }
   const slip: DepositSlipData = {
+    duplicate,
     alteration_id: alteration.id,
     alteration_no: alteration.alteration_no,
     received_at: alteration.received_at,

--- a/src/app/[locale]/(dashboard)/collections/[id]/page.tsx
+++ b/src/app/[locale]/(dashboard)/collections/[id]/page.tsx
@@ -1,3 +1,4 @@
+import { isReprintRequest, logReprint } from '@/actions/reprints';
 import { notFound } from 'next/navigation';
 import { getTranslations, setRequestLocale } from 'next-intl/server';
 import { getCollection } from '@/actions/orders';
@@ -6,7 +7,11 @@ import {
   type CollectionSlipData
 } from '@/components/receipt/collection-slip';
 
-type Props = { params: Promise<{ locale: string; id: string }> };
+type Props = {
+  params: Promise<{ locale: string; id: string }>;
+  /** `?reprint=1` marks the sheet DUPLICATA / DUPLICATE and logs it. */
+  searchParams: Promise<{ reprint?: string }>;
+};
 
 export async function generateMetadata({ params }: Props) {
   const { locale, id } = await params;
@@ -15,7 +20,7 @@ export async function generateMetadata({ params }: Props) {
   return { title: collection ? `${t('title')} ${collection.col_no}` : t('title') };
 }
 
-export default async function CollectionSlipPage({ params }: Props) {
+export default async function CollectionSlipPage({ params, searchParams }: Props) {
   const { locale, id } = await params;
   setRequestLocale(locale);
 
@@ -24,7 +29,16 @@ export default async function CollectionSlipPage({ params }: Props) {
   const collection = await getCollection(id);
   if (!collection || !collection.order) notFound();
 
+
+  // A reprint is stamped and recorded; the plain URL stays the original
+  // (A-FR-7.12).
+  const duplicate = await isReprintRequest(searchParams);
+  if (duplicate) {
+    await logReprint({ kind: 'collection', id: collection.id, reference: collection.col_no });
+  }
   const slip: CollectionSlipData = {
+    duplicate,
+    id: collection.id,
     col_no: collection.col_no,
     collected_at: collection.collected_at,
     collector_name: collection.collector_name,

--- a/src/app/[locale]/(dashboard)/orders/[id]/receipt/page.tsx
+++ b/src/app/[locale]/(dashboard)/orders/[id]/receipt/page.tsx
@@ -1,10 +1,15 @@
+import { isReprintRequest, logReprint } from '@/actions/reprints';
 import { notFound } from 'next/navigation';
 import { getTranslations, setRequestLocale } from 'next-intl/server';
 import { getOrderWithItems } from '@/actions/orders';
 import { ReceiptPrint, type ReceiptData } from '@/components/receipt/receipt-print';
 import { deriveOrderStatus } from '@/lib/order-status';
 
-type Props = { params: Promise<{ locale: string; id: string }> };
+type Props = {
+  params: Promise<{ locale: string; id: string }>;
+  /** `?reprint=1` marks the sheet DUPLICATA / DUPLICATE and logs it. */
+  searchParams: Promise<{ reprint?: string }>;
+};
 
 export async function generateMetadata({ params }: Props) {
   const { locale, id } = await params;
@@ -13,7 +18,7 @@ export async function generateMetadata({ params }: Props) {
   return { title: order ? `${t('orderTitle')} ${order.order_no}` : t('orderTitle') };
 }
 
-export default async function OrderReceiptPage({ params }: Props) {
+export default async function OrderReceiptPage({ params, searchParams }: Props) {
   const { locale, id } = await params;
   setRequestLocale(locale);
 
@@ -22,7 +27,16 @@ export default async function OrderReceiptPage({ params }: Props) {
   const order = await getOrderWithItems(id);
   if (!order) notFound();
 
+
+  // A reprint is stamped and recorded; the plain URL stays the original
+  // (A-FR-7.12).
+  const duplicate = await isReprintRequest(searchParams);
+  if (duplicate) {
+    await logReprint({ kind: 'order', id: order.id, reference: order.order_no });
+  }
   const receipt: ReceiptData = {
+    duplicate,
+    record_id: order.id,
     kind: 'order',
     // Derived from the lines, the same rule the detail page and the order list
     // use -- so all three agree about what this order currently is.

--- a/src/app/[locale]/(dashboard)/sales/[id]/receipt/page.tsx
+++ b/src/app/[locale]/(dashboard)/sales/[id]/receipt/page.tsx
@@ -1,9 +1,14 @@
+import { isReprintRequest, logReprint } from '@/actions/reprints';
 import { notFound } from 'next/navigation';
 import { getTranslations, setRequestLocale } from 'next-intl/server';
 import { getSaleWithItems } from '@/actions/sales';
 import { ReceiptPrint, type ReceiptData } from '@/components/receipt/receipt-print';
 
-type Props = { params: Promise<{ locale: string; id: string }> };
+type Props = {
+  params: Promise<{ locale: string; id: string }>;
+  /** `?reprint=1` marks the sheet DUPLICATA / DUPLICATE and logs it. */
+  searchParams: Promise<{ reprint?: string }>;
+};
 
 export async function generateMetadata({ params }: Props) {
   const { locale, id } = await params;
@@ -12,7 +17,7 @@ export async function generateMetadata({ params }: Props) {
   return { title: sale ? `${t('title')} ${sale.receipt_no}` : t('title') };
 }
 
-export default async function ReceiptPage({ params }: Props) {
+export default async function ReceiptPage({ params, searchParams }: Props) {
   const { locale, id } = await params;
   setRequestLocale(locale);
 
@@ -21,7 +26,16 @@ export default async function ReceiptPage({ params }: Props) {
   const sale = await getSaleWithItems(id);
   if (!sale) notFound();
 
+
+  // A reprint is stamped and recorded; the plain URL stays the original
+  // (A-FR-7.12).
+  const duplicate = await isReprintRequest(searchParams);
+  if (duplicate) {
+    await logReprint({ kind: 'sale', id: sale.id, reference: sale.receipt_no });
+  }
   const receipt: ReceiptData = {
+    duplicate,
+    record_id: sale.id,
     receipt_no: sale.receipt_no,
     sold_at: sale.sold_at,
     customer_name: sale.customer_name,

--- a/src/components/receipt/collection-slip.tsx
+++ b/src/components/receipt/collection-slip.tsx
@@ -1,12 +1,17 @@
 'use client';
 
 import { useLocale, useTranslations } from 'next-intl';
-import { Printer, ArrowLeft } from 'lucide-react';
+import { Printer, ArrowLeft, Copy } from 'lucide-react';
 import { Link } from '@/i18n/navigation';
 import { Button } from '@/components/ui/button';
+import { DuplicateStamp } from '@/components/receipt/duplicate-stamp';
 import { formatDateTime, formatMoney, SCHOOL } from '@/lib/format';
 
 export type CollectionSlipData = {
+  /** A reprint, stamped DUPLICATA / DUPLICATE (A-FR-7.12). */
+  duplicate?: boolean;
+  /** The collection's own id, so the slip can link to its own reprint. */
+  id: string;
   col_no: string;
   collected_at: string;
   collector_name: string;
@@ -41,6 +46,7 @@ export type CollectionSlipData = {
  */
 export function CollectionSlip({ slip }: { slip: CollectionSlipData }) {
   const t = useTranslations('Collection');
+  const tReceipt = useTranslations('Receipt');
   const locale = useLocale();
 
   return (
@@ -70,10 +76,20 @@ export function CollectionSlip({ slip }: { slip: CollectionSlipData }) {
             {t('backToOrder')}
           </Link>
         </Button>
-        <Button size="sm" onClick={() => window.print()}>
-          <Printer className="size-4" />
-          {t('print')}
-        </Button>
+        <div className="flex items-center gap-2">
+          {!slip.duplicate ? (
+            <Button asChild variant="outline" size="sm">
+              <Link href={`/collections/${slip.id}?reprint=1`}>
+                <Copy className="size-4" />
+                {tReceipt('reprint')}
+              </Link>
+            </Button>
+          ) : null}
+          <Button size="sm" onClick={() => window.print()}>
+            <Printer className="size-4" />
+            {t('print')}
+          </Button>
+        </div>
       </div>
 
       <article className="receipt-sheet mx-auto max-w-xl rounded-lg border bg-white p-8 text-black shadow-sm">
@@ -91,6 +107,7 @@ export function CollectionSlip({ slip }: { slip: CollectionSlipData }) {
               Retiré / Collected
             </p>
           </div>
+          {slip.duplicate ? <DuplicateStamp /> : null}
         </header>
 
         {/* The two references, side by side and equally weighted. */}

--- a/src/components/receipt/deposit-slip.tsx
+++ b/src/components/receipt/deposit-slip.tsx
@@ -1,13 +1,16 @@
 'use client';
 
 import { useLocale, useTranslations } from 'next-intl';
-import { Printer, ArrowLeft } from 'lucide-react';
+import { Printer, ArrowLeft, Copy } from 'lucide-react';
 import { Link } from '@/i18n/navigation';
 import { Button } from '@/components/ui/button';
+import { DuplicateStamp } from '@/components/receipt/duplicate-stamp';
 import { formatDate, formatDateTime, formatMoney, SCHOOL } from '@/lib/format';
 import type { PaymentMethod } from '@/types/database.types';
 
 export type DepositSlipData = {
+  /** A reprint, stamped DUPLICATA / DUPLICATE (A-FR-7.12). */
+  duplicate?: boolean;
   alteration_no: string;
   received_at: string;
   expected_ready_date: string | null;
@@ -39,6 +42,7 @@ export type DepositSlipData = {
  */
 export function DepositSlip({ slip }: { slip: DepositSlipData }) {
   const t = useTranslations('Alterations');
+  const tReceipt = useTranslations('Receipt');
   const tSales = useTranslations('Sales');
   const locale = useLocale();
 
@@ -69,10 +73,20 @@ export function DepositSlip({ slip }: { slip: DepositSlipData }) {
             {t('backToAlteration')}
           </Link>
         </Button>
-        <Button size="sm" onClick={() => window.print()}>
-          <Printer className="size-4" />
-          {t('printSlip')}
-        </Button>
+        <div className="flex items-center gap-2">
+          {!slip.duplicate ? (
+            <Button asChild variant="outline" size="sm">
+              <Link href={`/alterations/${slip.alteration_id}/slip?reprint=1`}>
+                <Copy className="size-4" />
+                {tReceipt('reprint')}
+              </Link>
+            </Button>
+          ) : null}
+          <Button size="sm" onClick={() => window.print()}>
+            <Printer className="size-4" />
+            {t('printSlip')}
+          </Button>
+        </div>
       </div>
 
       <article className="receipt-sheet mx-auto max-w-xl rounded-lg border bg-white p-8 text-black shadow-sm">
@@ -93,6 +107,7 @@ export function DepositSlip({ slip }: { slip: DepositSlipData }) {
               Vêtement confié à l&apos;école · Garment held by the school
             </p>
           </div>
+          {slip.duplicate ? <DuplicateStamp /> : null}
         </header>
 
         <dl className="grid grid-cols-2 gap-x-6 gap-y-1 border-b py-4 text-xs">

--- a/src/components/receipt/duplicate-stamp.tsx
+++ b/src/components/receipt/duplicate-stamp.tsx
@@ -1,0 +1,24 @@
+/**
+ * The reprint stamp (A-FR-7.12).
+ *
+ * Shared by all four printable documents so a duplicate looks the same
+ * whichever one it is -- someone checking paperwork at the counter should
+ * recognise it without reading, and four hand-rolled variants would drift.
+ *
+ * Bilingual and unconditional, like COMMANDE / ORDER and Retiré / Collected:
+ * whoever is handed this may not share the language the seller was working in,
+ * and this is the line that must not be missed.
+ *
+ * Deliberately heavy. A stamp that reads as decoration does not do the job the
+ * requirement asks of it, which is to stop a duplicate being presented as an
+ * original.
+ */
+export function DuplicateStamp() {
+  return (
+    <div className="mt-2 border-4 border-double border-black px-3 py-2">
+      <p className="text-lg font-black uppercase tracking-[0.2em]">
+        Duplicata / Duplicate
+      </p>
+    </div>
+  );
+}

--- a/src/components/receipt/receipt-print.tsx
+++ b/src/components/receipt/receipt-print.tsx
@@ -1,9 +1,10 @@
 'use client';
 
 import { useLocale, useTranslations } from 'next-intl';
-import { Printer, ArrowLeft } from 'lucide-react';
+import { Printer, ArrowLeft, Copy } from 'lucide-react';
 import { Link } from '@/i18n/navigation';
 import { Button } from '@/components/ui/button';
+import { DuplicateStamp } from '@/components/receipt/duplicate-stamp';
 import { formatDate, formatDateTime, formatMoney, SCHOOL } from '@/lib/format';
 import type { OrderStatus, PaymentMethod } from '@/types/database.types';
 
@@ -16,6 +17,13 @@ export type ReceiptData = {
   kind?: 'sale' | 'order';
   /** Carries `order_no` when kind is 'order'; the label switches with it. */
   receipt_no: string;
+  /**
+   * A reprint, stamped DUPLICATA / DUPLICATE (A-FR-7.12). Set by the route from
+   * the reprint URL, never inferred here -- the sheet renders what it is told.
+   */
+  duplicate?: boolean;
+  /** The sale or order id, so the sheet can link to its own reprint. */
+  record_id: string;
   /** Orders only. */
   expected_ready_date?: string | null;
   measurements?: string | null;
@@ -60,6 +68,10 @@ export function ReceiptPrint({ receipt }: { receipt: ReceiptData }) {
   const tPayment = useTranslations('Sales.payment');
   const locale = useLocale();
   const isOrder = receipt.kind === 'order';
+  // Where this sheet lives, so the reprint link can point back at itself.
+  const basePath = isOrder
+    ? `/orders/${receipt.record_id}/receipt`
+    : `/sales/${receipt.record_id}/receipt`;
 
   return (
     <>
@@ -89,10 +101,22 @@ export function ReceiptPrint({ receipt }: { receipt: ReceiptData }) {
             {isOrder ? t('backToOrders') : t('back')}
           </Link>
         </Button>
-        <Button size="sm" onClick={() => window.print()}>
-          <Printer className="size-4" />
-          {t('print')}
-        </Button>
+        <div className="flex items-center gap-2">
+          {/* Offered only on an original. From a duplicate the link would just
+              reload the same stamped sheet and log another reprint. */}
+          {!receipt.duplicate ? (
+            <Button asChild variant="outline" size="sm">
+              <Link href={`${basePath}?reprint=1`}>
+                <Copy className="size-4" />
+                {t('reprint')}
+              </Link>
+            </Button>
+          ) : null}
+          <Button size="sm" onClick={() => window.print()}>
+            <Printer className="size-4" />
+            {t('print')}
+          </Button>
+        </div>
       </div>
 
       <article className="receipt-sheet mx-auto max-w-xl rounded-lg border bg-white p-8 text-black shadow-sm">
@@ -131,6 +155,7 @@ export function ReceiptPrint({ receipt }: { receipt: ReceiptData }) {
           ) : (
             <p className="mt-2 text-sm font-semibold uppercase">{t('title')}</p>
           )}
+          {receipt.duplicate ? <DuplicateStamp /> : null}
         </header>
 
         <dl className="grid grid-cols-2 gap-x-6 gap-y-1 border-b py-4 text-xs">


### PR DESCRIPTION
Closes #30

Requirement: A-FR-7.12

## What this does
A reprint is stamped so it can't be presented as an original, and logged so
"how many copies of this exist, and who asked for them" has an answer weeks
later. The stamp warns whoever is holding the paper; the log is the half the
stamp can't cover.

Covers **all four** printable documents — sale receipt, order receipt,
collection slip, deposit slip. A duplicate collection or deposit slip is at
least as dangerous as a duplicate receipt, since those prove the school handed
goods over or is holding someone else's property. Return receipts join when #38
lands.

## Details worth reviewing
- **One shared stamp component**, not four copies — a duplicate should look
  identical whichever document it is, and four variants would drift. Bilingual
  and unconditional, matching `COMMANDE / ORDER` and `Retiré / Collected`.
  Deliberately heavy: a stamp that reads as decoration doesn't do its job.
- **The Reprint button only shows on an original.** From a duplicate it would
  reload the same stamped sheet and log another reprint for nothing.
- **Logging happens on render, not on the Print click**, so a reprint is
  recorded even if the operator uses Ctrl+P or photographs the screen. Reloading
  therefore logs again — the right way round: each render did put another
  duplicate on screen, and an audit trail that under-reports is worse than one
  that repeats.

## Known limit, chosen deliberately
The flag lives in the URL, so **trimming `?reprint=1` yields an unstamped copy** —
the stamp deters rather than prevents. This was a decision, not an oversight; the
alternative (recording on each record whether it had ever been printed, so every
later render stamps regardless of URL) was considered and not taken. The
limitation is documented in `reprints.ts` so it isn't mistaken for a bug later.

## Testing
No SQL needed — `logAudit` uses columns already live. Open a receipt (no stamp),
click Réimprimer (stamped), check `/fr/audit` for a `document_reprinted` entry
with who and when. Same on all four documents.