### PR TITLE
PR/feat(stock): adjustments with a mandatory reason

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -561,6 +561,23 @@
     "size": "Size",
     "quantity": "Quantity"
   },
+  "Adjustment": {
+    "adjust": "Adjust",
+    "title": "Adjust stock",
+    "direction": "Direction",
+    "add": "Add",
+    "remove": "Remove",
+    "quantity": "Quantity",
+    "reason": "Reason",
+    "reasonHint": "e.g. damaged in production, physical count, defect, loss",
+    "resulting": "{from} → {to}",
+    "willGoNegative": "this will go below zero",
+    "ledgerNotice": "The count is not overwritten — the difference is recorded as a movement, so the discrepancy stays visible.",
+    "cancel": "Cancel",
+    "record": "Record adjustment",
+    "recording": "Recording…",
+    "recorded": "Adjustment recorded for {product}."
+  },
   "Production": {
     "title": "Record production",
     "subtitle": "Enter garments as they come out of production. Stock rises from these entries — it is never typed in directly.",
@@ -594,6 +611,7 @@
     "wholeNumber": "Enter a whole number.",
     "discountTooLarge": "Discount cannot exceed the subtotal.",
     "invalidDate": "Enter a valid date.",
+    "nonZero": "Enter a quantity other than zero.",
     "describeMore": "Please describe what happened (at least 10 characters).",
     "nothingToPay": "There is no charge to pay.",
     "workRequired": "Describe the work required (at least 3 characters).",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -561,6 +561,23 @@
     "size": "Taille",
     "quantity": "Quantité"
   },
+  "Adjustment": {
+    "adjust": "Ajuster",
+    "title": "Ajuster le stock",
+    "direction": "Sens",
+    "add": "Ajouter",
+    "remove": "Retirer",
+    "quantity": "Quantité",
+    "reason": "Motif",
+    "reasonHint": "ex. endommagé en production, comptage physique, défaut, perte",
+    "resulting": "{from} → {to}",
+    "willGoNegative": "passera sous zéro",
+    "ledgerNotice": "Le compte n’est pas écrasé — la différence est enregistrée comme un mouvement, l’écart reste donc visible.",
+    "cancel": "Annuler",
+    "record": "Enregistrer l’ajustement",
+    "recording": "Enregistrement…",
+    "recorded": "Ajustement enregistré pour {product}."
+  },
   "Production": {
     "title": "Enregistrer la production",
     "subtitle": "Saisissez les articles à leur sortie de production. Le stock découle de ces saisies — il n’est jamais saisi directement.",
@@ -594,6 +611,7 @@
     "wholeNumber": "Saisissez un nombre entier.",
     "discountTooLarge": "La remise ne peut d\u00e9passer le sous-total.",
     "invalidDate": "Saisissez une date valide.",
+    "nonZero": "Saisissez une quantité différente de zéro.",
     "describeMore": "Décrivez ce qui s’est passé (au moins 10 caractères).",
     "nothingToPay": "Il n’y a aucun frais à payer.",
     "workRequired": "Décrivez les travaux à effectuer (au moins 3 caractères).",

--- a/src/actions/stock.ts
+++ b/src/actions/stock.ts
@@ -4,7 +4,9 @@ import { revalidatePath } from 'next/cache';
 import { createClient } from '@/lib/supabase/server';
 import { logAudit } from '@/lib/audit';
 import {
+  adjustmentSchema,
   productionBatchSchema,
+  type AdjustmentInput,
   type ProductionBatchInput
 } from '@/lib/validation/production-schema';
 import type { StockMovementKind } from '@/types/database.types';
@@ -232,4 +234,85 @@ export async function listRecentProduction(limit = 20) {
     .order('created_at', { ascending: false })
     .limit(limit);
   return data ?? [];
+}
+
+// ------------------------------------------------------------- adjustments
+
+export type AdjustmentResult =
+  | { ok: true }
+  | { ok: false; error: string; fieldErrors?: Record<string, string> };
+
+/**
+ * Corrects a stock level, with a mandatory reason (A-FR-5.5).
+ *
+ * The correction is a MOVEMENT, never a write to stock_levels. That is the
+ * whole discipline of this table: the balance is derived by the
+ * apply_stock_movement trigger, so a count that disagrees is recorded as the
+ * difference rather than by overwriting the number. The old value stays
+ * visible in the ledger, which is what makes an adjustment auditable at all --
+ * overwriting would erase the very discrepancy being reported.
+ *
+ * A single insert, so there is no batch to make atomic and no database function
+ * needed. The audit row is written here rather than by a trigger, because a
+ * trigger on stock_movements would also fire for production and collection
+ * movements, which already record themselves elsewhere and would then be
+ * logged twice.
+ */
+export async function recordStockAdjustment(
+  input: AdjustmentInput
+): Promise<AdjustmentResult> {
+  const parsed = adjustmentSchema.safeParse(input);
+  if (!parsed.success) {
+    const fieldErrors: Record<string, string> = {};
+    for (const issue of parsed.error.issues) {
+      fieldErrors[issue.path.join('.')] ??= issue.message;
+    }
+    return { ok: false, error: 'validation', fieldErrors };
+  }
+
+  const supabase = await createClient();
+  const {
+    data: { user }
+  } = await supabase.auth.getUser();
+  if (!user) return { ok: false, error: 'unauthorized' };
+
+  const { productId, quantity, reason } = parsed.data;
+
+  const { data: product } = await supabase
+    .from('products')
+    .select('name_en, size')
+    .eq('id', productId)
+    .single();
+
+  const { error } = await supabase.from('stock_movements').insert({
+    product_id: productId,
+    kind: 'adjustment',
+    quantity,
+    note: reason,
+    occurred_on: new Date().toISOString().slice(0, 10),
+    created_by: user.id
+  });
+
+  if (error) return { ok: false, error: error.message };
+
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('full_name')
+    .eq('id', user.id)
+    .single();
+
+  await logAudit({
+    actorId: user.id,
+    actorName: profile?.full_name ?? user.email ?? null,
+    action: 'stock_adjusted',
+    entity: product ? `${product.name_en}${product.size ? ` (${product.size})` : ''}` : productId,
+    targetTable: 'stock_movements',
+    targetId: productId,
+    // The reason is the point of the record, so it goes in the audit row too
+    // rather than only in the movement it describes.
+    meta: { product_id: productId, quantity, reason }
+  });
+
+  revalidatePath('/stock', 'page');
+  return { ok: true };
 }

--- a/src/app/[locale]/(dashboard)/stock/page.tsx
+++ b/src/app/[locale]/(dashboard)/stock/page.tsx
@@ -7,6 +7,7 @@ import {
 } from '@/actions/stock';
 import { listWaitingOrderCounts } from '@/actions/orders';
 import { ProductionForm } from '@/components/forms/production-form';
+import { AdjustStockDialog } from '@/components/forms/adjust-stock-dialog';
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import {
@@ -106,6 +107,7 @@ export default async function StockPage({ params }: Props) {
                   <TableHead>{t('product')}</TableHead>
                   <TableHead>{t('size')}</TableHead>
                   <TableHead className="text-right">{t('quantity')}</TableHead>
+                  <TableHead className="w-0" />
                 </TableRow>
               </TableHeader>
               <TableBody>
@@ -119,6 +121,17 @@ export default async function StockPage({ params }: Props) {
                       <span className={product.isLow ? 'text-destructive font-medium' : ''}>
                         {product.quantity}
                       </span>
+                    </TableCell>
+                    <TableCell className="text-right">
+                      {/* Opened from the row whose number is wrong, so there is
+                          no product to pick (A-FR-5.5). */}
+                      <AdjustStockDialog
+                        productId={product.id}
+                        productLabel={
+                          product.size ? `${name(product)} — ${product.size}` : name(product)
+                        }
+                        currentQuantity={product.quantity}
+                      />
                     </TableCell>
                   </TableRow>
                 ))}

--- a/src/components/forms/adjust-stock-dialog.tsx
+++ b/src/components/forms/adjust-stock-dialog.tsx
@@ -1,0 +1,189 @@
+'use client';
+
+import { useState, useTransition } from 'react';
+import { useTranslations } from 'next-intl';
+import { toast } from 'sonner';
+import { Scale, Minus, Plus } from 'lucide-react';
+import { useRouter } from '@/i18n/navigation';
+import { recordStockAdjustment } from '@/actions/stock';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+
+/**
+ * Correcting one product's stock (A-FR-5.5).
+ *
+ * Opened from the row whose number is wrong, so there is no product picker to
+ * get right -- you are looking at a count that disagrees and correcting that
+ * line.
+ *
+ * The signed quantity is entered as a magnitude plus a direction rather than as
+ * a number that might carry a minus sign. "-2" typed into a box is easy to mean
+ * and easy to mistype, and the difference between +2 and -2 here is four
+ * garments.
+ */
+export function AdjustStockDialog({
+  productId,
+  productLabel,
+  currentQuantity
+}: {
+  productId: string;
+  productLabel: string;
+  currentQuantity: number;
+}) {
+  const t = useTranslations('Adjustment');
+  const tv = useTranslations('Validation');
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+
+  const [open, setOpen] = useState(false);
+  const [direction, setDirection] = useState<'add' | 'remove'>('remove');
+  const [amount, setAmount] = useState('');
+  const [reason, setReason] = useState('');
+  const [errors, setErrors] = useState<{ amount?: string; reason?: string }>({});
+
+  const magnitude = Math.abs(Math.trunc(Number(amount) || 0));
+  const signed = direction === 'add' ? magnitude : -magnitude;
+  const resulting = currentQuantity + signed;
+
+  function submit() {
+    const next: typeof errors = {};
+    if (magnitude === 0) next.amount = tv('nonZero');
+    if (reason.trim().length < 3) next.reason = tv('reasonRequired');
+    setErrors(next);
+    if (Object.keys(next).length > 0) return;
+
+    startTransition(async () => {
+      const result = await recordStockAdjustment({
+        productId,
+        quantity: signed,
+        reason
+      });
+
+      if (!result.ok) {
+        toast.error(result.error === 'validation' ? tv('reasonRequired') : result.error);
+        return;
+      }
+
+      toast.success(t('recorded', { product: productLabel }));
+      setOpen(false);
+      setAmount('');
+      setReason('');
+      setErrors({});
+      router.refresh();
+    });
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button variant="ghost" size="sm">
+          <Scale className="size-3.5" />
+          {t('adjust')}
+        </Button>
+      </DialogTrigger>
+
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{t('title')}</DialogTitle>
+          <DialogDescription>{productLabel}</DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <Label>{t('direction')}</Label>
+            <div className="flex gap-2">
+              <Button
+                type="button"
+                variant={direction === 'remove' ? 'default' : 'outline'}
+                size="sm"
+                onClick={() => setDirection('remove')}
+              >
+                <Minus className="size-3.5" />
+                {t('remove')}
+              </Button>
+              <Button
+                type="button"
+                variant={direction === 'add' ? 'default' : 'outline'}
+                size="sm"
+                onClick={() => setDirection('add')}
+              >
+                <Plus className="size-3.5" />
+                {t('add')}
+              </Button>
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor={`adjust-amount-${productId}`}>{t('quantity')}</Label>
+            <Input
+              id={`adjust-amount-${productId}`}
+              type="number"
+              min={1}
+              step={1}
+              inputMode="numeric"
+              value={amount}
+              onChange={(event) => setAmount(event.target.value)}
+              aria-invalid={Boolean(errors.amount)}
+            />
+            {errors.amount ? (
+              <p className="text-sm text-destructive">{errors.amount}</p>
+            ) : null}
+            {/* Shown before submitting, because a negative result is legitimate
+                but should never be a surprise. */}
+            {magnitude > 0 ? (
+              <p
+                className={
+                  resulting < 0
+                    ? 'text-xs font-medium text-amber-600 dark:text-amber-500'
+                    : 'text-xs text-muted-foreground'
+                }
+              >
+                {t('resulting', { from: currentQuantity, to: resulting })}
+                {resulting < 0 ? ` — ${t('willGoNegative')}` : ''}
+              </p>
+            ) : null}
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor={`adjust-reason-${productId}`}>{t('reason')}</Label>
+            <Textarea
+              id={`adjust-reason-${productId}`}
+              rows={3}
+              value={reason}
+              onChange={(event) => setReason(event.target.value)}
+              placeholder={t('reasonHint')}
+              aria-invalid={Boolean(errors.reason)}
+            />
+            {errors.reason ? (
+              <p className="text-sm text-destructive">{errors.reason}</p>
+            ) : null}
+          </div>
+
+          {/* Said plainly: the count is not overwritten, the difference is
+              recorded. That is what makes it auditable. */}
+          <p className="text-xs text-muted-foreground">{t('ledgerNotice')}</p>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => setOpen(false)}>
+            {t('cancel')}
+          </Button>
+          <Button onClick={submit} disabled={isPending}>
+            {isPending ? t('recording') : t('record')}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/lib/validation/production-schema.ts
+++ b/src/lib/validation/production-schema.ts
@@ -56,3 +56,35 @@ export const EMPTY_PRODUCTION_LINE: ProductionLineInput = {
 export function totalUnits(lines: readonly { quantity: unknown }[]): number {
   return lines.reduce((sum, line) => sum + (Number(line.quantity) || 0), 0);
 }
+
+// ------------------------------------------------------------- adjustments
+
+/**
+ * Stock adjustment (A-FR-5.5): a physical count that disagrees, damage, a
+ * defect, a loss.
+ *
+ * Mirrors the stock_movements_adjustment_needs_reason constraint added in
+ * 20260101002000. The database refuses an unexplained adjustment whatever the
+ * form does; this is the message the seller actually reads.
+ */
+export const adjustmentSchema = z.object({
+  productId: z.uuid({ message: 'required' }),
+  /**
+   * Signed and non-zero. Positive adds, negative removes -- a count that came
+   * out two short is -2, not "remove 2", because the ledger reads as arithmetic
+   * on the balance rather than as a pair of opposite verbs.
+   */
+  quantity: z.coerce
+    .number({ message: 'positive' })
+    .int({ message: 'wholeNumber' })
+    .refine((n) => n !== 0, { message: 'nonZero' })
+    .refine((n) => Math.abs(n) <= 10000, { message: 'positive' }),
+  /** Three characters minimum: "x" answers nothing when read back. */
+  reason: z
+    .string({ message: 'reasonRequired' })
+    .trim()
+    .min(3, { message: 'reasonRequired' })
+    .max(500)
+});
+
+export type AdjustmentInput = z.input<typeof adjustmentSchema>;

--- a/supabase/migrations/20260101002000_adjustment_reason.sql
+++ b/supabase/migrations/20260101002000_adjustment_reason.sql
@@ -1,0 +1,22 @@
+-- Stock adjustments must say why (A-FR-5.5).
+--
+-- An adjustment is how the ledger admits it was wrong: a physical count that
+-- disagrees, a garment damaged in production, a defect, a loss. Every other
+-- movement carries its own explanation in its kind -- a sale is a sale, a
+-- collection is a collection -- but an adjustment explains nothing by itself.
+-- An unexplained one is indistinguishable from a mistake, or from theft.
+--
+-- `note` stays nullable because production entries and collections legitimately
+-- have none. The rule is conditional: only adjustments are required to fill it.
+-- Enforced here rather than in the form, for the same reason as every other
+-- rule in this schema -- anything holding the anon key can insert a row
+-- directly, and a mandatory field the UI alone enforces is not mandatory.
+--
+-- Three characters, not one: "x" satisfies a NOT NULL and answers nothing when
+-- the row is read back six months later.
+
+alter table public.stock_movements
+  add constraint stock_movements_adjustment_needs_reason check (
+    kind <> 'adjustment'
+    or (note is not null and length(btrim(note)) >= 3)
+  );

--- a/supabase/migrations/rollback/20260101002000_adjustment_reason_down.sql
+++ b/supabase/migrations/rollback/20260101002000_adjustment_reason_down.sql
@@ -1,0 +1,11 @@
+-- Rollback for 20260101002000_adjustment_reason.sql.
+--
+-- MANUAL ONLY -- see supabase/README.md.
+--
+-- Dropping this constraint makes it possible again to record a stock
+-- adjustment with no explanation, which is the one thing A-FR-5.5 exists to
+-- prevent. Rows already written keep their reasons; only future ones lose the
+-- guarantee.
+
+alter table public.stock_movements
+  drop constraint if exists stock_movements_adjustment_needs_reason;


### PR DESCRIPTION
Closes #21

Requirement: A-FR-5.5

## What this does
An adjustment is how the ledger admits it was wrong: a physical count that
disagrees, a garment damaged in production, a defect, a loss.

Every other movement explains itself by its kind — a sale is a sale, a
collection is a collection — but an adjustment explains nothing on its own. An
unexplained one is indistinguishable from a mistake, or from theft. Hence the
mandatory reason.

## Decisions worth reviewing
- **Enforced by a CHECK constraint, not the form.** Anything holding the anon key
  can insert directly, and a mandatory field the UI alone enforces isn't
  mandatory. `note` stays nullable — production entries and collections
  legitimately have none — so the rule is conditional on `kind`. Three characters
  minimum: "x" satisfies a NOT NULL and answers nothing six months later.
- **The count is never overwritten.** The *difference* is recorded as a movement
  and the balance is derived by the trigger, so the discrepancy stays visible.
  Overwriting would erase the very thing the adjustment exists to report.
- **Opened from the row whose number is wrong**, so there's no product picker to
  get right.
- **Magnitude plus direction, not a signed number.** "-2" is easy to mean and easy
  to mistype, and the difference between +2 and −2 here is four garments. The
  resulting balance is shown before submitting and flagged when it would fall
  below zero — legitimate, but never a surprise.
- **Audited in the action, not by a trigger.** A trigger on `stock_movements`
  would also fire for production and collection movements, which already record
  themselves and would then be logged twice.

## Verified against the database, before the UI existed
| Insert | Result |
|---|---|
| adjustment, no note | rejected |
| adjustment, blank note | rejected |
| adjustment, note `"x"` | rejected |
| production, no note | accepted (nullable preserved) |
| adjustment with a real reason | accepted |

No policy changes needed — `stock_movements_insert_admin` already covers operators.