### PR TITLE
PR/feat(stock): show In stock / Reserved / Available and offer Available on sales

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -308,6 +308,7 @@
     "selectProduct": "Select a product",
     "size": "Size",
     "unitPrice": "Unit price",
+    "availableShort": "{count} available",
     "quantity": "Qty",
     "lineTotal": "Total",
     "subtotal": "Subtotal",
@@ -556,6 +557,9 @@
   },
   "Stock": {
     "title": "Production & stock",
+    "inStock": "In stock",
+    "reserved": "Reserved",
+    "available": "Available",
     "onHand": "On hand",
     "product": "Product",
     "size": "Size",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -308,6 +308,7 @@
     "selectProduct": "Choisir un article",
     "size": "Taille",
     "unitPrice": "Prix unitaire",
+    "availableShort": "{count} disponible(s)",
     "quantity": "Qt\u00e9",
     "lineTotal": "Total",
     "subtotal": "Sous-total",
@@ -556,6 +557,9 @@
   },
   "Stock": {
     "title": "Production et stock",
+    "inStock": "En stock",
+    "reserved": "Réservé",
+    "available": "Disponible",
     "onHand": "En stock",
     "product": "Produit",
     "size": "Taille",

--- a/src/actions/stock.ts
+++ b/src/actions/stock.ts
@@ -35,14 +35,61 @@ export async function listStock() {
     .order('category')
     .order('name_en');
 
+  const reserved = await reservedByProduct();
+
   return (data ?? []).map((product) => {
     // stock_levels is one row per product, but PostgREST embeds it as an array
     // because the foreign key lives on the stock_levels side.
     const level = Array.isArray(product.level) ? product.level[0] : product.level;
     const quantity = level?.quantity ?? 0;
     const reorderLevel = level?.reorder_level ?? 0;
-    return { ...product, quantity, reorderLevel, isLow: quantity <= reorderLevel };
+    const reservedQty = reserved[product.id] ?? 0;
+    return {
+      ...product,
+      quantity,
+      reorderLevel,
+      // Derived, never stored: a second copy of this number would drift the
+      // moment an order moved to Ready without the copy being updated.
+      reserved: reservedQty,
+      // May go negative, and is shown that way. Hiding it would conceal the
+      // oversell it exists to reveal (A-FR-9.10).
+      available: quantity - reservedQty,
+      isLow: quantity <= reorderLevel
+    };
   });
+}
+
+/**
+ * How many of each product are spoken for (A-FR-9.9).
+ *
+ * Reserved means order lines that have reached 'ready' -- and only those. A
+ * garment still 'ordered' or 'in_production' does not physically exist yet, so
+ * it cannot be reserved out of stock you are holding. Once it is Ready it does
+ * exist, sitting on the shelf with someone's name on it, and that is precisely
+ * the shirt that must not be sold to a walk-in customer.
+ *
+ * That makes this the exact complement of listWaitingOrderCounts(), which
+ * covers 'ordered' and 'in_production': together they account for every open
+ * line, with no overlap and no gap.
+ *
+ * Sums line QUANTITIES, not line counts -- two Ready lines of three shirts
+ * reserve six. Lines with no product_id are free text and cannot be attributed,
+ * so this is a floor rather than a total.
+ */
+export async function reservedByProduct(): Promise<Record<string, number>> {
+  const supabase = await createClient();
+  const { data } = await supabase
+    .from('order_items')
+    .select('product_id, quantity')
+    .eq('status', 'ready')
+    .not('product_id', 'is', null);
+
+  const reserved: Record<string, number> = {};
+  for (const line of data ?? []) {
+    if (!line.product_id) continue;
+    reserved[line.product_id] = (reserved[line.product_id] ?? 0) + line.quantity;
+  }
+  return reserved;
 }
 
 export type StockMovementResult =
@@ -128,15 +175,42 @@ export async function deductStockForSale(
 }
 
 /** Catalogue rows for the sale form's product picker. */
+/**
+ * Products for the sale and production selectors, carrying what is actually
+ * available to sell (A-FR-9.10).
+ *
+ * The sale screen works from Available rather than In stock, because a Ready
+ * order line is a garment already promised to a named parent. Selling it to
+ * whoever is at the counter is the double-sale this whole feature exists to
+ * prevent.
+ *
+ * Shown, not enforced: below-stock sales are permitted with a warning, an
+ * override and an audit row, which is its own issue. Blocking here would have
+ * to be undone there.
+ */
 export async function listProducts() {
   const supabase = await createClient();
-  const { data } = await supabase
-    .from('products')
-    .select('id, sku, name_en, name_fr, size, unit_price, category')
-    .eq('is_active', true)
-    .order('category')
-    .order('name_en');
-  return data ?? [];
+  const [{ data }, reserved] = await Promise.all([
+    supabase
+      .from('products')
+      .select('id, sku, name_en, name_fr, size, unit_price, category, level:stock_levels ( quantity )')
+      .eq('is_active', true)
+      .order('category')
+      .order('name_en'),
+    reservedByProduct()
+  ]);
+
+  return (data ?? []).map((product) => {
+    const level = Array.isArray(product.level) ? product.level[0] : product.level;
+    const quantity = level?.quantity ?? 0;
+    const reservedQty = reserved[product.id] ?? 0;
+    return {
+      ...product,
+      inStock: quantity,
+      reserved: reservedQty,
+      available: quantity - reservedQty
+    };
+  });
 }
 
 // ------------------------------------------------------------- production

--- a/src/app/[locale]/(dashboard)/stock/page.tsx
+++ b/src/app/[locale]/(dashboard)/stock/page.tsx
@@ -106,7 +106,9 @@ export default async function StockPage({ params }: Props) {
                 <TableRow>
                   <TableHead>{t('product')}</TableHead>
                   <TableHead>{t('size')}</TableHead>
-                  <TableHead className="text-right">{t('quantity')}</TableHead>
+                  <TableHead className="text-right">{t('inStock')}</TableHead>
+                  <TableHead className="text-right">{t('reserved')}</TableHead>
+                  <TableHead className="text-right">{t('available')}</TableHead>
                   <TableHead className="w-0" />
                 </TableRow>
               </TableHeader>
@@ -120,6 +122,20 @@ export default async function StockPage({ params }: Props) {
                     <TableCell className="text-right tabular-nums">
                       <span className={product.isLow ? 'text-destructive font-medium' : ''}>
                         {product.quantity}
+                      </span>
+                    </TableCell>
+                    {/* Reserved is dimmed at zero: nothing is spoken for, so
+                        there is nothing to think about. */}
+                    <TableCell className="text-right tabular-nums">
+                      <span className={product.reserved > 0 ? '' : 'text-muted-foreground'}>
+                        {product.reserved}
+                      </span>
+                    </TableCell>
+                    {/* Available is the number that decides whether a walk-in
+                        can be served, so it carries the weight (A-FR-9.10). */}
+                    <TableCell className="text-right tabular-nums font-medium">
+                      <span className={product.available <= 0 ? 'text-destructive' : ''}>
+                        {product.available}
                       </span>
                     </TableCell>
                     <TableCell className="text-right">

--- a/src/components/forms/sale-form.tsx
+++ b/src/components/forms/sale-form.tsx
@@ -44,6 +44,14 @@ export type ProductOption = {
   size: string | null;
   unit_price: number;
   category: string;
+  /**
+   * What can actually be sold: in stock minus what Ready orders have already
+   * claimed (A-FR-9.10). Optional so the production form, which cares about
+   * neither, can keep passing the same shape.
+   */
+  available?: number;
+  inStock?: number;
+  reserved?: number;
 };
 
 const DEFAULTS: SaleInput = {
@@ -222,6 +230,11 @@ export function SaleForm({ products }: { products: ProductOption[] }) {
         <CardContent className="space-y-4">
           {fields.map((field, index) => {
             const itemErrors = formState.errors.items?.[index];
+            const chosenId = watchedItems?.[index]?.productId;
+            const chosen = chosenId
+              ? products.find((candidate) => candidate.id === chosenId)
+              : undefined;
+            const wanted = Number(watchedItems?.[index]?.quantity) || 0;
             const line =
               (Number(watchedItems?.[index]?.unitPrice) || 0) *
               (Number(watchedItems?.[index]?.quantity) || 0);
@@ -242,7 +255,23 @@ export function SaleForm({ products }: { products: ProductOption[] }) {
                     <SelectContent>
                       {products.map((product) => (
                         <SelectItem key={product.id} value={product.id}>
-                          {productLabel(product)}
+                          <span className="flex w-full items-center justify-between gap-3">
+                            <span>{productLabel(product)}</span>
+                            {/* Availability sits beside the name so the seller
+                                reads it while choosing rather than discovering
+                                it afterwards. */}
+                            {typeof product.available === 'number' ? (
+                              <span
+                                className={
+                                  product.available <= 0
+                                    ? 'text-xs font-medium text-destructive'
+                                    : 'text-xs text-muted-foreground'
+                                }
+                              >
+                                {t('availableShort', { count: product.available })}
+                              </span>
+                            ) : null}
+                          </span>
                         </SelectItem>
                       ))}
                     </SelectContent>
@@ -286,6 +315,21 @@ export function SaleForm({ products }: { products: ProductOption[] }) {
                     inputMode="numeric"
                     aria-invalid={Boolean(itemErrors?.quantity)}
                   />
+                  {/* Shown, never enforced: selling below stock is allowed with
+                      a warning, an override and an audit row, which is a
+                      separate issue. A hard cap here would have to be undone
+                      there. */}
+                  {chosen && typeof chosen.available === 'number' ? (
+                    <p
+                      className={
+                        wanted > chosen.available
+                          ? 'mt-1 text-xs font-medium text-amber-600 dark:text-amber-500'
+                          : 'mt-1 text-xs text-muted-foreground'
+                      }
+                    >
+                      {t('availableShort', { count: chosen.available })}
+                    </p>
+                  ) : null}
                 </div>
 
                 <div className="flex items-end justify-between gap-2 sm:col-span-3">


### PR DESCRIPTION
Closes #22

Requirements: A-FR-9.8, A-FR-9.9, A-FR-9.10

## What this does
The part that prevents the same shirt being sold twice.

**Reserved counts order lines that have reached `ready`, and only those.** A
garment still `ordered` or `in_production` doesn't physically exist yet, so it
can't be reserved out of stock the shop is holding. Once it's Ready it does exist
— on the shelf, with someone's name on it — and that's exactly the shirt that
must not be sold to whoever walks in next.

That makes this the precise complement of the waiting count on production entry,
which covers `ordered` + `in_production`. Between them every open line is
accounted for once, with no overlap and no gap.

## Decisions worth reviewing
- **Derived on read, never stored.** A stored copy of Reserved or Available would
  drift the moment an order moved to Ready without the copy being updated — which
  is the double-sale this feature exists to prevent.
- **Available may go negative** and is shown that way, in red. Hiding it would
  conceal the oversell it exists to reveal.
- **Quantities are summed, not lines** — two Ready lines of three shirts reserve six.
- **Free-text lines** (no `product_id`) can't be attributed, so Reserved is a floor.

## Shown, not enforced
The sale screen shows Available beside each product in the picker and again under
the quantity, turning amber when more is asked for than exists — but it does not
block. Below-stock sales are permitted with a warning, an override and an audit
row, which is **#25**. A hard cap here would only have to be undone there.

## Verified against live data
| Product | In stock | Reserved | Available |
|---|---|---|---|
| T-shirt (XL) | 200 | 1 | **199** |
| Tie (XL) | 99 | 0 | 99 |
| Shirt (M) | 200 | 0 | 200 |

The single Ready order line (T-shirt, qty 1) is the only thing reserving anything.