### PR TITLE
PR/feat(sales): three payment methods, payment reference, and separate recorded-by / received-by

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -298,9 +298,13 @@
     "paymentMethod": "Payment method",
     "payment": {
       "cash": "Cash",
-      "mobile_money": "Mobile money",
-      "bank_transfer": "Bank transfer"
+      "mobile_money": "MoMo",
+      "orange_money": "Orange Money"
     },
+    "paymentReference": "Payment reference",
+    "paymentReferenceHint": "MoMo / Orange Money transaction ID",
+    "recordedBy": "Recorded by",
+    "receivedBy": "Payment received by",
     "items": "Items",
     "addItem": "Add item",
     "removeItem": "Remove",
@@ -527,7 +531,8 @@
     "orderFooter": "Thank you. The garment stays in the shop until collected.",
     "backToOrders": "Back to orders",
     "date": "Date",
-    "servedBy": "Served by",
+    "recordedBy": "Recorded by",
+    "receivedBy": "Payment received by",
     "customer": "Customer",
     "student": "Student",
     "class": "Class",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -297,10 +297,14 @@
     "phone": "T\u00e9l\u00e9phone",
     "paymentMethod": "Mode de paiement",
     "payment": {
-      "cash": "Esp\u00e8ces",
-      "mobile_money": "Mobile money",
-      "bank_transfer": "Virement bancaire"
+      "cash": "Espèces",
+      "mobile_money": "MoMo",
+      "orange_money": "Orange Money"
     },
+    "paymentReference": "Référence du paiement",
+    "paymentReferenceHint": "ID de transaction MoMo / Orange Money",
+    "recordedBy": "Enregistré par",
+    "receivedBy": "Paiement reçu par",
     "items": "Articles",
     "addItem": "Ajouter un article",
     "removeItem": "Retirer",
@@ -527,7 +531,8 @@
     "orderFooter": "Merci. Le v\u00eatement reste en boutique jusqu'au retrait.",
     "backToOrders": "Retour aux commandes",
     "date": "Date",
-    "servedBy": "Servi par",
+    "recordedBy": "Enregistré par",
+    "receivedBy": "Paiement reçu par",
     "customer": "Client",
     "student": "\u00c9l\u00e8ve",
     "class": "Classe",

--- a/src/actions/sales.ts
+++ b/src/actions/sales.ts
@@ -61,6 +61,16 @@ export async function createSale(input: SaleInput): Promise<CreateSaleResult> {
       total,
       notes: sale.notes,
       signature_url: sale.signature,
+      payment_reference: sale.paymentReference,
+      // Attribution: who keyed it, who took the money. Defaulted to the
+      // session user when the form leaves them alone.
+      recorded_by: sale.recordedBy ?? user.id,
+      received_by: sale.receivedBy ?? user.id,
+      // Unchanged and unchangeable: the account that actually submitted this
+      // row, and the value the RLS insert policy checks against auth.uid().
+      // The two attribution columns above sit alongside it rather than
+      // replacing it, so a tampered payload still cannot file a sale under
+      // somebody else's name.
       seller_id: user.id
     })
     .select('id, receipt_no')
@@ -131,8 +141,11 @@ export async function getSaleWithItems(saleId: string) {
     .from('sales')
     .select(
       `id, receipt_no, sold_at, customer_name, student_name, class_level, phone,
-       payment_method, subtotal, discount, total, notes, signature_url,
+       payment_method, payment_reference, subtotal, discount, total, notes,
+       signature_url,
        seller:profiles!sales_seller_id_fkey ( full_name ),
+       recordedBy:profiles!sales_recorded_by_fkey ( full_name ),
+       receivedBy:profiles!sales_received_by_fkey ( full_name ),
        items:sale_items ( id, description, size, unit_price, quantity, line_total )`
     )
     .eq('id', saleId)

--- a/src/app/[locale]/(dashboard)/sales/[id]/receipt/page.tsx
+++ b/src/app/[locale]/(dashboard)/sales/[id]/receipt/page.tsx
@@ -48,6 +48,9 @@ export default async function ReceiptPage({ params, searchParams }: Props) {
     notes: sale.notes,
     signature_url: sale.signature_url,
     seller_name: sale.seller?.full_name ?? '',
+    recorded_by_name: sale.recordedBy?.full_name ?? null,
+    received_by_name: sale.receivedBy?.full_name ?? null,
+    payment_reference: sale.payment_reference,
     items: sale.items ?? []
   };
 

--- a/src/app/[locale]/(dashboard)/sales/page.tsx
+++ b/src/app/[locale]/(dashboard)/sales/page.tsx
@@ -2,6 +2,8 @@ import { getTranslations, setRequestLocale } from 'next-intl/server';
 import { Link } from '@/i18n/navigation';
 import { listRecentSales } from '@/actions/sales';
 import { listProducts } from '@/actions/stock';
+import { listStaff } from '@/actions/orders';
+import { getProfile } from '@/actions/auth';
 import { SaleForm } from '@/components/forms/sale-form';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -22,9 +24,11 @@ export default async function SalesPage({ params }: Props) {
 
   // Both hit the same connection pool; fetch them together rather than
   // waterfalling the product list behind the recent-sales query.
-  const [products, recent, t] = await Promise.all([
+  const [products, recent, staff, profile, t] = await Promise.all([
     listProducts(),
     listRecentSales(8),
+    listStaff(),
+    getProfile(),
     getTranslations('Sales')
   ]);
 
@@ -35,7 +39,11 @@ export default async function SalesPage({ params }: Props) {
           <h1 className="text-2xl font-semibold tracking-tight">{t('title')}</h1>
           <p className="text-sm text-muted-foreground">{t('subtitle')}</p>
         </div>
-        <SaleForm products={products} />
+        <SaleForm
+          products={products}
+          staff={staff}
+          currentUserId={profile?.id ?? ''}
+        />
       </div>
 
       <Card className="h-fit lg:sticky lg:top-6">

--- a/src/components/forms/sale-form.tsx
+++ b/src/components/forms/sale-form.tsx
@@ -63,10 +63,22 @@ const DEFAULTS: SaleInput = {
   items: [{ ...EMPTY_SALE_ITEM }],
   discount: 0,
   notes: null,
-  signature: null
+  signature: null,
+  recordedBy: null,
+  receivedBy: null,
+  paymentReference: null
 };
 
-export function SaleForm({ products }: { products: ProductOption[] }) {
+export function SaleForm({
+  products,
+  staff,
+  currentUserId
+}: {
+  products: ProductOption[];
+  /** Active staff, for the two attribution selectors (A-FR-6.4, A-FR-6.5). */
+  staff: { id: string; full_name: string }[];
+  currentUserId: string;
+}) {
   const t = useTranslations('Sales');
   const tv = useTranslations('Validation');
   const locale = useLocale();
@@ -76,7 +88,10 @@ export function SaleForm({ products }: { products: ProductOption[] }) {
 
   const form = useForm<SaleInput>({
     resolver: standardSchemaResolver(saleSchema),
-    defaultValues: DEFAULTS,
+    // Both attributions start as whoever is signed in, which is right far more
+    // often than not -- the selectors exist for the shared-till case, not as a
+    // question the seller must answer on every sale.
+    defaultValues: { ...DEFAULTS, recordedBy: currentUserId, receivedBy: currentUserId },
     mode: 'onSubmit'
   });
 
@@ -87,6 +102,10 @@ export function SaleForm({ products }: { products: ProductOption[] }) {
   // keystroke without re-rendering the whole form tree twice.
   const watchedItems = useWatch({ control, name: 'items' });
   const watchedDiscount = useWatch({ control, name: 'discount' });
+  const watchedMethod = useWatch({ control, name: 'paymentMethod' });
+  // Cash has no transaction to reference, so the field would be noise.
+  const needsReference =
+    watchedMethod === 'mobile_money' || watchedMethod === 'orange_money';
 
   const totals = useMemo(() => {
     const lines = (watchedItems ?? []).map((item) => ({
@@ -204,6 +223,54 @@ export function SaleForm({ products }: { products: ProductOption[] }) {
                 {PAYMENT_METHODS.map((method) => (
                   <SelectItem key={method} value={method}>
                     {t(`payment.${method}`)}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </Field>
+          {needsReference ? (
+            <Field label={t('paymentReference')}>
+              <Input
+                {...register('paymentReference')}
+                placeholder={t('paymentReferenceHint')}
+                inputMode="text"
+              />
+            </Field>
+          ) : null}
+
+          <Field label={t('recordedBy')}>
+            <Select
+              defaultValue={currentUserId}
+              onValueChange={(value) => setValue('recordedBy', value, { shouldDirty: true })}
+            >
+              <SelectTrigger className="w-full">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {staff.map((person) => (
+                  <SelectItem key={person.id} value={person.id}>
+                    {person.full_name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </Field>
+
+          {/* Separate from "recorded by" on purpose: when the drawer is short
+              at close of day, who keyed the sale is not the question
+              (A-FR-6.5). */}
+          <Field label={t('receivedBy')}>
+            <Select
+              defaultValue={currentUserId}
+              onValueChange={(value) => setValue('receivedBy', value, { shouldDirty: true })}
+            >
+              <SelectTrigger className="w-full">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {staff.map((person) => (
+                  <SelectItem key={person.id} value={person.id}>
+                    {person.full_name}
                   </SelectItem>
                 ))}
               </SelectContent>

--- a/src/components/receipt/receipt-print.tsx
+++ b/src/components/receipt/receipt-print.tsx
@@ -45,6 +45,14 @@ export type ReceiptData = {
   notes: string | null;
   signature_url: string | null;
   seller_name: string;
+  /**
+   * Both printed, because the spec asks for both (A-FR-6.4, A-FR-6.5) and they
+   * answer different questions. Fall back to the seller for rows written
+   * before the columns existed rather than printing a blank line.
+   */
+  recorded_by_name?: string | null;
+  received_by_name?: string | null;
+  payment_reference?: string | null;
   items: {
     id: string;
     description: string;
@@ -178,7 +186,14 @@ export function ReceiptPrint({ receipt }: { receipt: ReceiptData }) {
           {receipt.class_level ? (
             <Meta label={t('class')} value={receipt.class_level} />
           ) : null}
-          <Meta label={t('servedBy')} value={receipt.seller_name} />
+          <Meta
+            label={t('recordedBy')}
+            value={receipt.recorded_by_name || receipt.seller_name}
+          />
+          <Meta
+            label={t('receivedBy')}
+            value={receipt.received_by_name || receipt.seller_name}
+          />
         </dl>
 
         <table className="w-full border-collapse py-4 text-xs">
@@ -242,6 +257,11 @@ export function ReceiptPrint({ receipt }: { receipt: ReceiptData }) {
         <p className="mt-3 text-xs">
           <span className="text-neutral-600">{t('paymentMethod')}: </span>
           {tPayment(receipt.payment_method)}
+          {/* The transaction ID is what a parent quotes when a mobile payment
+              is disputed, so it belongs on the paper they keep. */}
+          {receipt.payment_reference ? (
+            <span className="font-mono"> · {receipt.payment_reference}</span>
+          ) : null}
         </p>
 
         {isOrder && receipt.measurements ? (

--- a/src/lib/excel-export.ts
+++ b/src/lib/excel-export.ts
@@ -38,9 +38,19 @@ export type ExportOptions = {
   schoolName: string;
 };
 
+/**
+ * MoMo and Orange Money are named separately because they are separate
+ * providers with separate float and separate statements -- an export that
+ * calls both "mobile money" cannot be reconciled against either.
+ *
+ * 'bank_transfer' is unused but still in the database type, which cannot drop
+ * values, so it needs a label for exhaustiveness rather than because anything
+ * will print it.
+ */
 const PAYMENT_LABELS: Record<PaymentMethod, string> = {
   cash: 'Cash',
-  mobile_money: 'Mobile money',
+  mobile_money: 'MoMo',
+  orange_money: 'Orange Money',
   bank_transfer: 'Bank transfer'
 };
 

--- a/src/lib/validation/sale-schema.ts
+++ b/src/lib/validation/sale-schema.ts
@@ -9,7 +9,16 @@ import { z } from 'zod';
  * `useValidationMessage()` in the form. See messages/en.json.
  */
 
-export const PAYMENT_METHODS = ['cash', 'mobile_money', 'bank_transfer'] as const;
+/**
+ * The three the spec names (A-FR-6.3): Cash, MoMo, Orange Money.
+ *
+ * MoMo is stored as 'mobile_money' -- the value predates the requirement and
+ * every existing row using it was MTN, since Orange had no way of being
+ * recorded before. 'bank_transfer' survives in the database type, which cannot
+ * drop values, but is deliberately absent here so nothing new is filed under
+ * it.
+ */
+export const PAYMENT_METHODS = ['cash', 'mobile_money', 'orange_money'] as const;
 export type PaymentMethodValue = (typeof PAYMENT_METHODS)[number];
 
 /** Money is stored as numeric(12,2); round before comparing or persisting. */
@@ -50,6 +59,24 @@ export const saleSchema = z
     items: z.array(saleItemSchema).min(1, { message: 'minItems' }).max(50),
     discount: money.default(0),
     notes: z.string().trim().max(500).nullable().default(null),
+    /**
+     * Who keyed the sale and who took the money (A-FR-6.4, A-FR-6.5). Two
+     * questions, two answers: on a shared till one person is signed in while
+     * another serves the parent, and when the drawer is short at close of day
+     * only the second one helps.
+     *
+     * Both default to the signed-in user in the form. Neither is the RLS
+     * anchor -- `seller_id` still comes from the session and is never accepted
+     * from the payload.
+     */
+    recordedBy: z.uuid({ message: 'required' }).nullable().default(null),
+    receivedBy: z.uuid({ message: 'required' }).nullable().default(null),
+    /**
+     * MoMo or Orange Money transaction ID. Never required: a parent does not
+     * always have it to hand, and refusing the sale over a reference number
+     * would stop the shop working.
+     */
+    paymentReference: z.string().trim().max(100).nullable().default(null),
     /** Phase 2: data URL captured by the signature pad. */
     signature: z.string().nullable().default(null)
   })

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -15,7 +15,16 @@ export type Json =
   | Json[];
 
 export type UserRole = 'seller' | 'administration' | 'maintenance' | 'super_admin';
-export type PaymentMethod = 'cash' | 'mobile_money' | 'bank_transfer';
+/**
+ * 'bank_transfer' is retained because Postgres cannot remove an enum value, but
+ * the app no longer offers it -- the spec names Cash, MoMo and Orange Money
+ * (A-FR-6.3), and no row anywhere uses it.
+ */
+export type PaymentMethod =
+  | 'cash'
+  | 'mobile_money'
+  | 'orange_money'
+  | 'bank_transfer';
 export type StockMovementKind =
   | 'intake'
   | 'sale'
@@ -224,6 +233,9 @@ export type Database = {
           notes: string | null;
           signature_url: string | null;
           seller_id: string;
+          recorded_by: string | null;
+          received_by: string | null;
+          payment_reference: string | null;
           created_at: string;
           updated_at: string;
         };
@@ -242,6 +254,9 @@ export type Database = {
           notes?: string | null;
           signature_url?: string | null;
           seller_id: string;
+          recorded_by?: string | null;
+          received_by?: string | null;
+          payment_reference?: string | null;
           created_at?: string;
           updated_at?: string;
         };
@@ -260,10 +275,25 @@ export type Database = {
           notes?: string | null;
           signature_url?: string | null;
           seller_id?: string;
+          recorded_by?: string | null;
+          received_by?: string | null;
+          payment_reference?: string | null;
           created_at?: string;
           updated_at?: string;
         };
         Relationships: [
+          {
+            foreignKeyName: 'sales_recorded_by_fkey';
+            columns: ['recorded_by'];
+            referencedRelation: 'profiles';
+            referencedColumns: ['id'];
+          },
+          {
+            foreignKeyName: 'sales_received_by_fkey';
+            columns: ['received_by'];
+            referencedRelation: 'profiles';
+            referencedColumns: ['id'];
+          },
           {
             foreignKeyName: 'sales_seller_id_fkey';
             columns: ['seller_id'];

--- a/supabase/migrations/20260101002100_orange_money.sql
+++ b/supabase/migrations/20260101002100_orange_money.sql
@@ -1,0 +1,16 @@
+-- Orange Money as its own payment method (A-FR-6.3).
+--
+-- The spec names three: Cash, MoMo, Orange Money. MTN Mobile Money and Orange
+-- Money are separate providers with separate float, separate statements and
+-- separate reconciliation -- collapsing both into one 'mobile_money' loses
+-- which one actually took the money, and the daily cash reconciliation cannot
+-- balance a till it cannot break down.
+--
+-- Existing 'mobile_money' rows are left alone and read as MoMo, which is what
+-- they were: Orange Money had no way of being recorded before this, so nothing
+-- filed under mobile_money could have been Orange.
+--
+-- 'bank_transfer' is not in the spec's list. It stays in the type because
+-- Postgres cannot remove an enum value, but the UI stops offering it -- no row
+-- anywhere currently uses it, so nothing is stranded.
+alter type public.payment_method add value if not exists 'orange_money';

--- a/supabase/migrations/20260101002200_sale_attribution.sql
+++ b/supabase/migrations/20260101002200_sale_attribution.sql
@@ -1,0 +1,39 @@
+-- Who recorded the sale, and who took the money (A-FR-6.4, A-FR-6.5).
+--
+-- These are two different questions and the spec wants both answered. On a
+-- shared till one person is signed in while another serves the parent and
+-- counts the cash; when the drawer is short at close of day, "who was logged
+-- in" is not the same as "who received the payment", and only the second one
+-- helps.
+--
+-- seller_id is deliberately NOT reused for either. It stays what it has always
+-- been: the account that actually submitted the row, unchangeable, and the key
+-- the RLS insert policy checks against auth.uid(). If it became editable, a
+-- tampered payload could attribute a sale to somebody else -- which is exactly
+-- what that policy exists to prevent. So attribution is recorded alongside it
+-- rather than on top of it. The two usually agree; the point is that they are
+-- allowed not to.
+--
+-- Separate migration from 20260101002100 because that one adds an enum value,
+-- and Postgres will not let a value added in a transaction be used by the same
+-- transaction.
+
+alter table public.sales
+  -- Both nullable: rows written before this migration have no answer, and
+  -- inventing one would be a guess recorded as a fact. The receipt falls back
+  -- to the seller for those.
+  add column recorded_by uuid references public.profiles (id),
+  add column received_by uuid references public.profiles (id),
+  -- The MoMo or Orange Money transaction ID. Optional on purpose -- a parent
+  -- does not always have it to hand, and refusing the sale over a reference
+  -- number would stop the shop working.
+  add column payment_reference text;
+
+-- Existing sales were recorded and received by whoever was signed in, which is
+-- the only thing that was true of them.
+update public.sales
+   set recorded_by = seller_id,
+       received_by = seller_id
+ where recorded_by is null;
+
+create index sales_received_by_idx on public.sales (received_by, sold_at desc);

--- a/supabase/migrations/rollback/20260101002100_orange_money_down.sql
+++ b/supabase/migrations/rollback/20260101002100_orange_money_down.sql
@@ -1,0 +1,11 @@
+-- Rollback for 20260101002100_orange_money.sql.
+--
+-- MANUAL ONLY -- see supabase/README.md.
+--
+-- Deliberately a no-op. Postgres cannot remove a value from an enum, so
+-- 'orange_money' is permanent once added. Any sale already recorded against it
+-- would also have nowhere to go: rewriting those rows to 'mobile_money' would
+-- state that Orange took money MTN actually took.
+--
+-- If Orange Money must stop being offered, remove it from the selector in the
+-- application. The type keeps the value; nothing new gets filed under it.

--- a/supabase/migrations/rollback/20260101002200_sale_attribution_down.sql
+++ b/supabase/migrations/rollback/20260101002200_sale_attribution_down.sql
@@ -1,0 +1,16 @@
+-- Rollback for 20260101002200_sale_attribution.sql.
+--
+-- MANUAL ONLY -- see supabase/README.md. Run this BEFORE
+-- 20260101002100_orange_money_down.sql (which is itself a no-op).
+--
+-- Caveat: this destroys who received each payment, which is the record that
+-- settles a short drawer. seller_id survives, but it answers a different
+-- question -- who was signed in, not who counted the cash. Export sales before
+-- running this anywhere real.
+
+drop index if exists public.sales_received_by_idx;
+
+alter table public.sales
+  drop column if exists payment_reference,
+  drop column if exists received_by,
+  drop column if exists recorded_by;


### PR DESCRIPTION
Closes #23

Requirements: A-FR-6.1, A-FR-6.3, A-FR-6.4, A-FR-6.5

The most-used screen in the system, so every addition here is one that costs the
seller nothing on a normal sale.

## Payment methods are now the three the spec names
Cash, **MoMo**, **Orange Money**.

MTN Mobile Money and Orange Money are separate providers with separate float and
separate statements — collapsing both into one `mobile_money` loses which one took
the money, and a daily reconciliation can't balance a till it can't break down.

- Existing `mobile_money` rows are left alone and read as MoMo, which is what they
  were: Orange had no way of being recorded before this.
- `bank_transfer` isn't in the spec's list and is no longer offered. Postgres can't
  drop an enum value, so it survives in the type — unused by any row.
- The Excel export labels them separately too, which #43's reconciliation will need.

## Recorded by ≠ Payment received by
Two questions, and the spec wants both answered. On a shared till one person is
signed in while another serves the parent and counts the cash. When the drawer is
short at close of day, *"who was logged in"* is not the same as *"who received the
payment"* — and only the second one helps.

**`seller_id` is deliberately not reused for either.** It stays the account that
actually submitted the row, and the value the RLS insert policy checks against
`auth.uid()`. Making it editable would let a tampered payload file a sale under
someone else's name — exactly what that policy prevents. So attribution sits
*alongside* it. The three usually agree; the point is they're allowed not to.

Both default to the signed-in user, so a normal sale needs no extra thought.

## Payment reference
Appears only for MoMo and Orange Money — cash has no transaction to quote — and is
never required, because a parent doesn't always have the ID to hand and refusing a
sale over a reference number would stop the shop working. It prints on the receipt,
since that's the number quoted when a mobile payment is disputed.

## Migration safety
Existing sales are backfilled from `seller_id`, the only thing that was true of
them, so no receipt prints a blank attribution line.

Verified against the database: a sale with `recorded_by` and `received_by` set to
different people is accepted and stored as such, with `orange_money` and a reference.