### PR TITLE
PR/feat(search): unified search across sales, orders and alterations

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -14,7 +14,6 @@
     "toggleTheme": "Toggle theme",
     "menu": "Menu",
     "searchPlaceholder": "Search sales, receipts, products…",
-    "searchHint": "Search is coming soon.",
     "notifications": "Notifications",
     "notificationsEmpty": "You're all caught up.",
     "sections": {
@@ -287,6 +286,32 @@
     "unexpectedError": "Something went wrong. Please try again.",
     "tooManyAttempts": "Too many failed attempts. Try again in a few minutes.",
     "sessionExpired": "Your session expired. Please sign in again."
+  },
+  "Search": {
+    "title": "Search",
+    "subtitle": "Find a sale, order or alteration by reference, student, parent or phone.",
+    "label": "Search",
+    "placeholder": "Reference, student, parent or phone…",
+    "search": "Search",
+    "from": "From",
+    "to": "To",
+    "anyStage": "Any status",
+    "open": "Open",
+    "kind": {
+      "sale": "Sales",
+      "order": "Orders",
+      "alteration": "Alterations"
+    },
+    "stage": {
+      "waiting": "Waiting",
+      "in_progress": "In progress",
+      "ready": "Ready"
+    },
+    "resultCount": "{count} result(s)",
+    "noResults": "Nothing matched that search.",
+    "previous": "Previous",
+    "next": "Next",
+    "pageOf": "Page {page} of {pages}"
   },
   "Sales": {
     "title": "New sale",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -14,7 +14,6 @@
     "toggleTheme": "Changer de th\u00e8me",
     "menu": "Menu",
     "searchPlaceholder": "Rechercher ventes, re\u00e7us, produits\u2026",
-    "searchHint": "La recherche arrive bient\u00f4t.",
     "notifications": "Notifications",
     "notificationsEmpty": "Vous \u00eates \u00e0 jour.",
     "sections": {
@@ -287,6 +286,32 @@
     "unexpectedError": "Une erreur est survenue. Veuillez r\u00e9essayer.",
     "tooManyAttempts": "Trop de tentatives \u00e9chou\u00e9es. R\u00e9essayez dans quelques minutes.",
     "sessionExpired": "Votre session a expir\u00e9. Veuillez vous reconnecter."
+  },
+  "Search": {
+    "title": "Recherche",
+    "subtitle": "Retrouver une vente, une commande ou une retouche par référence, élève, parent ou téléphone.",
+    "label": "Rechercher",
+    "placeholder": "Référence, élève, parent ou téléphone…",
+    "search": "Rechercher",
+    "from": "Du",
+    "to": "Au",
+    "anyStage": "Tout statut",
+    "open": "Ouvrir",
+    "kind": {
+      "sale": "Ventes",
+      "order": "Commandes",
+      "alteration": "Retouches"
+    },
+    "stage": {
+      "waiting": "En attente",
+      "in_progress": "En cours",
+      "ready": "Prêt"
+    },
+    "resultCount": "{count} résultat(s)",
+    "noResults": "Aucun résultat pour cette recherche.",
+    "previous": "Précédent",
+    "next": "Suivant",
+    "pageOf": "Page {page} sur {pages}"
   },
   "Sales": {
     "title": "Nouvelle vente",

--- a/src/actions/search.ts
+++ b/src/actions/search.ts
@@ -1,0 +1,56 @@
+'use server';
+
+import { createClient } from '@/lib/supabase/server';
+import { SEARCH_PAGE_SIZE, type SearchResults, type TransactionKind } from '@/lib/search';
+
+/**
+ * Unified search across sales, orders and alterations (A-FR-7.6).
+ *
+ * All the work happens in `search_transactions()`. It runs as the caller, so
+ * RLS decides what comes back -- a seller finds their own transactions, an
+ * oversight role finds everything -- and no permission logic is repeated here.
+ */
+
+export async function searchTransactions(params: {
+  term?: string | null;
+  kinds?: TransactionKind[] | null;
+  stage?: string | null;
+  from?: string | null;
+  to?: string | null;
+  page?: number;
+}): Promise<SearchResults> {
+  const supabase = await createClient();
+  const page = Math.max(1, params.page ?? 1);
+
+  const { data } = await supabase.rpc('search_transactions', {
+    p_term: params.term?.trim() || null,
+    p_kinds: params.kinds && params.kinds.length > 0 ? params.kinds : null,
+    p_stage: params.stage || null,
+    p_from: params.from || null,
+    p_to: params.to || null,
+    p_limit: SEARCH_PAGE_SIZE,
+    p_offset: (page - 1) * SEARCH_PAGE_SIZE
+  });
+
+  const rows = data ?? [];
+
+  return {
+    // total_count rides on every row -- a window count over the full match --
+    // so the page can say "34 results" while holding twenty of them. Zero rows
+    // means zero matches, which is the only case where it is absent.
+    total: rows.length > 0 ? Number(rows[0].total_count) : 0,
+    page,
+    pageSize: SEARCH_PAGE_SIZE,
+    hits: rows.map((row) => ({
+      kind: row.kind as TransactionKind,
+      id: row.id,
+      reference: row.reference,
+      occurredAt: row.occurred_at,
+      customerName: row.customer_name,
+      studentName: row.student_name,
+      phone: row.phone,
+      status: row.status,
+      amount: row.amount
+    }))
+  };
+}

--- a/src/app/[locale]/(dashboard)/search/page.tsx
+++ b/src/app/[locale]/(dashboard)/search/page.tsx
@@ -1,0 +1,70 @@
+import { getTranslations, setRequestLocale } from 'next-intl/server';
+import { searchTransactions } from '@/actions/search';
+import type { TransactionKind } from '@/lib/search';
+import { SearchPanel } from '@/components/search/search-panel';
+
+type Props = {
+  params: Promise<{ locale: string }>;
+  searchParams: Promise<{
+    q?: string;
+    kind?: string;
+    stage?: string;
+    from?: string;
+    to?: string;
+    page?: string;
+  }>;
+};
+
+const ALL_KINDS: TransactionKind[] = ['sale', 'order', 'alteration'];
+
+export async function generateMetadata({ params }: Props) {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: 'Search' });
+  return { title: t('title') };
+}
+
+export default async function SearchPage({ params, searchParams }: Props) {
+  const { locale } = await params;
+  setRequestLocale(locale);
+
+  const sp = await searchParams;
+
+  // The whole query lives in the URL so a search can be bookmarked, shared with
+  // a colleague or survive a reload -- on a screen whose job is "find it
+  // again", losing the search on refresh would be the wrong failure.
+  const kinds = sp.kind
+    ? (sp.kind.split(',').filter((k) => ALL_KINDS.includes(k as TransactionKind)) as TransactionKind[])
+    : ALL_KINDS;
+
+  const [results, t] = await Promise.all([
+    searchTransactions({
+      term: sp.q ?? null,
+      kinds,
+      stage: sp.stage ?? null,
+      from: sp.from ?? null,
+      to: sp.to ?? null,
+      page: Number(sp.page) || 1
+    }),
+    getTranslations('Search')
+  ]);
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-1">
+        <h1 className="text-2xl font-semibold tracking-tight">{t('title')}</h1>
+        <p className="text-sm text-muted-foreground">{t('subtitle')}</p>
+      </div>
+
+      <SearchPanel
+        results={results}
+        query={{
+          term: sp.q ?? '',
+          kinds,
+          stage: sp.stage ?? '',
+          from: sp.from ?? '',
+          to: sp.to ?? ''
+        }}
+      />
+    </div>
+  );
+}

--- a/src/components/dashboard/dashboard-shell.tsx
+++ b/src/components/dashboard/dashboard-shell.tsx
@@ -3,8 +3,7 @@
 import { useState } from 'react';
 import { MenuIcon, XIcon, LogOutIcon, SearchIcon } from 'lucide-react';
 import { useTranslations } from 'next-intl';
-import { toast } from 'sonner';
-import { Link, usePathname } from '@/i18n/navigation';
+import { Link, usePathname, useRouter } from '@/i18n/navigation';
 import { signOut } from '@/actions/auth';
 import { SchoolLogo } from '@/components/brand/school-logo';
 import { LanguageSwitcher } from '@/components/language-switcher';
@@ -48,6 +47,7 @@ export function DashboardShell({
 }) {
   const t = useTranslations('Nav');
   const [mobileOpen, setMobileOpen] = useState(false);
+  const router = useRouter();
   const items = navItemsFor(role);
 
   return (
@@ -98,10 +98,15 @@ export function DashboardShell({
             <SchoolLogo size="sm" />
           </div>
 
+          {/* The box was a placeholder that only raised a toast; it now goes
+              to the real search (A-FR-7.6). Present on every screen, because a
+              parent can turn up at the counter mid-anything. */}
           <form
             onSubmit={(e) => {
               e.preventDefault();
-              toast.info(t('searchHint'));
+              const q = new FormData(e.currentTarget).get('q');
+              const term = typeof q === 'string' ? q.trim() : '';
+              router.push(term ? `/search?q=${encodeURIComponent(term)}` : '/search');
             }}
             className="relative hidden max-w-xl flex-1 md:block"
           >

--- a/src/components/search/search-panel.tsx
+++ b/src/components/search/search-panel.tsx
@@ -1,0 +1,252 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from '@/i18n/navigation';
+import { useLocale, useTranslations } from 'next-intl';
+import { Search, ShoppingCart, PackagePlus, Scissors } from 'lucide-react';
+import { Link } from '@/i18n/navigation';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { formatDateTime, formatMoney } from '@/lib/format';
+import { JOB_STAGES } from '@/lib/open-jobs';
+import { hrefForHit, type SearchHit, type SearchResults, type TransactionKind } from '@/lib/search';
+
+/**
+ * The search screen (A-FR-7.6).
+ *
+ * Most parents arrive without their receipt, so the reference number is the
+ * least likely thing anyone will have. One box takes whatever they do have --
+ * a name, a phone number, or the reference if they kept it.
+ *
+ * Filtering is done by navigating rather than by fetching in place: the query
+ * lives in the URL, so a search can be bookmarked, shared with a colleague, or
+ * survive a reload. On a screen whose whole job is "find the thing again",
+ * losing the search on refresh would be the wrong failure.
+ */
+
+const KINDS: TransactionKind[] = ['sale', 'order', 'alteration'];
+
+const ICON = {
+  sale: ShoppingCart,
+  order: PackagePlus,
+  alteration: Scissors
+} as const;
+
+export function SearchPanel({
+  results,
+  query
+}: {
+  results: SearchResults;
+  query: { term: string; kinds: TransactionKind[]; stage: string; from: string; to: string };
+}) {
+  const t = useTranslations('Search');
+  const tOrders = useTranslations('Orders');
+  const tAlt = useTranslations('Alterations');
+  const locale = useLocale();
+  const router = useRouter();
+
+  const [term, setTerm] = useState(query.term);
+
+  function go(next: Partial<typeof query> & { page?: number }) {
+    const merged = { ...query, ...next };
+    const params = new URLSearchParams();
+    if (merged.term) params.set('q', merged.term);
+    if (merged.kinds.length > 0 && merged.kinds.length < KINDS.length) {
+      params.set('kind', merged.kinds.join(','));
+    }
+    if (merged.stage) params.set('stage', merged.stage);
+    if (merged.from) params.set('from', merged.from);
+    if (merged.to) params.set('to', merged.to);
+    if (next.page && next.page > 1) params.set('page', String(next.page));
+    router.push(`/search?${params.toString()}`);
+  }
+
+  function toggleKind(kind: TransactionKind) {
+    const active = query.kinds.includes(kind);
+    const next = active ? query.kinds.filter((k) => k !== kind) : [...query.kinds, kind];
+    // Deselecting the last one means "all", not "none" -- an empty result set
+    // caused by an empty filter reads as "nothing found", which is a lie.
+    go({ kinds: next.length === 0 ? KINDS : next });
+  }
+
+  /** A sale has no status; the others use their own words. */
+  const statusLabel = (hit: SearchHit) => {
+    if (!hit.status) return null;
+    return hit.kind === 'order'
+      ? tOrders(`status.${hit.status}`)
+      : tAlt(`status.${hit.status}`);
+  };
+
+  const lastPage = Math.max(1, Math.ceil(results.total / results.pageSize));
+
+  return (
+    <div className="space-y-4">
+      <form
+        onSubmit={(event) => {
+          event.preventDefault();
+          go({ term, page: 1 });
+        }}
+        className="flex flex-wrap items-end gap-2"
+      >
+        <div className="relative min-w-[18rem] flex-1">
+          <Label htmlFor="q" className="mb-2 text-xs text-muted-foreground">
+            {t('label')}
+          </Label>
+          <Search className="pointer-events-none absolute left-2.5 top-[2.15rem] size-4 text-muted-foreground" />
+          <Input
+            id="q"
+            value={term}
+            onChange={(event) => setTerm(event.target.value)}
+            placeholder={t('placeholder')}
+            className="pl-8"
+          />
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="from" className="text-xs text-muted-foreground">
+            {t('from')}
+          </Label>
+          <Input
+            id="from"
+            type="date"
+            value={query.from}
+            onChange={(event) => go({ from: event.target.value, page: 1 })}
+          />
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="to" className="text-xs text-muted-foreground">
+            {t('to')}
+          </Label>
+          <Input
+            id="to"
+            type="date"
+            value={query.to}
+            onChange={(event) => go({ to: event.target.value, page: 1 })}
+          />
+        </div>
+
+        <Button type="submit">{t('search')}</Button>
+      </form>
+
+      <div className="flex flex-wrap items-center gap-2">
+        {KINDS.map((kind) => (
+          <Button
+            key={kind}
+            type="button"
+            size="sm"
+            variant={query.kinds.includes(kind) ? 'default' : 'outline'}
+            onClick={() => toggleKind(kind)}
+          >
+            {t(`kind.${kind}`)}
+          </Button>
+        ))}
+
+        <span className="mx-1 h-5 w-px bg-border" />
+
+        {/* Only narrows the two kinds that have a status. A sale simply
+            happened, so choosing a stage excludes sales entirely rather than
+            pretending they have one. */}
+        <Button
+          type="button"
+          size="sm"
+          variant={query.stage === '' ? 'default' : 'outline'}
+          onClick={() => go({ stage: '', page: 1 })}
+        >
+          {t('anyStage')}
+        </Button>
+        {JOB_STAGES.map((stage) => (
+          <Button
+            key={stage}
+            type="button"
+            size="sm"
+            variant={query.stage === stage ? 'default' : 'outline'}
+            onClick={() => go({ stage, page: 1 })}
+          >
+            {t(`stage.${stage}`)}
+          </Button>
+        ))}
+      </div>
+
+      <p className="text-sm text-muted-foreground">
+        {results.total === 0 ? t('noResults') : t('resultCount', { count: results.total })}
+      </p>
+
+      <div className="space-y-2">
+        {results.hits.map((hit) => {
+          const Icon = ICON[hit.kind];
+          const status = statusLabel(hit);
+          return (
+            <Card key={`${hit.kind}:${hit.id}`}>
+              <CardContent className="flex flex-wrap items-center justify-between gap-3 p-4">
+                <div className="flex min-w-0 items-start gap-3">
+                  <Icon className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+                  <div className="min-w-0">
+                    <p className="flex flex-wrap items-center gap-2">
+                      <Badge variant="secondary" className="font-mono text-[0.7rem]">
+                        {hit.reference}
+                      </Badge>
+                      {status ? (
+                        <Badge variant="outline" className="text-[0.7rem]">
+                          {status}
+                        </Badge>
+                      ) : null}
+                    </p>
+                    <p className="mt-1 truncate text-sm font-medium">
+                      {hit.customerName}
+                      {hit.studentName ? (
+                        <span className="text-muted-foreground"> · {hit.studentName}</span>
+                      ) : null}
+                    </p>
+                    <p className="truncate text-xs text-muted-foreground">
+                      {formatDateTime(hit.occurredAt, locale)}
+                      {hit.phone ? ` · ${hit.phone}` : ''}
+                    </p>
+                  </div>
+                </div>
+
+                <div className="flex shrink-0 items-center gap-3">
+                  <span className="tabular-nums text-sm font-medium">
+                    {formatMoney(hit.amount, locale)}
+                  </span>
+                  <Button asChild variant="outline" size="sm">
+                    <Link href={hrefForHit(hit)}>{t('open')}</Link>
+                  </Button>
+                </div>
+              </CardContent>
+            </Card>
+          );
+        })}
+      </div>
+
+      {lastPage > 1 ? (
+        <div className="flex items-center justify-between gap-3 pt-2">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            disabled={results.page <= 1}
+            onClick={() => go({ page: results.page - 1 })}
+          >
+            {t('previous')}
+          </Button>
+          <span className="text-sm text-muted-foreground">
+            {t('pageOf', { page: results.page, pages: lastPage })}
+          </span>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            disabled={results.page >= lastPage}
+            onClick={() => go({ page: results.page + 1 })}
+          >
+            {t('next')}
+          </Button>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/lib/search.ts
+++ b/src/lib/search.ts
@@ -1,0 +1,46 @@
+/**
+ * Shapes and constants for the unified search (A-FR-7.6).
+ *
+ * Deliberately NOT in actions/search.ts: a 'use server' file may only export
+ * async functions, so a plain constant there is a build error rather than a
+ * style problem. Types are erased and would survive, but keeping them with the
+ * constant means one obvious home for "what a search result is" and one for
+ * "how a search is run".
+ */
+
+export type TransactionKind = 'sale' | 'order' | 'alteration';
+
+export type SearchHit = {
+  kind: TransactionKind;
+  id: string;
+  reference: string;
+  occurredAt: string;
+  customerName: string;
+  studentName: string | null;
+  phone: string | null;
+  /** Null for sales, which have no status -- a sale simply happened. */
+  status: string | null;
+  amount: number;
+};
+
+export type SearchResults = {
+  hits: SearchHit[];
+  /** Across the whole match, not just this page. */
+  total: number;
+  page: number;
+  pageSize: number;
+};
+
+export const SEARCH_PAGE_SIZE = 20;
+
+/** Where a hit lives, so a result can be opened. */
+export function hrefForHit(hit: SearchHit): string {
+  switch (hit.kind) {
+    case 'sale':
+      return `/sales/${hit.id}/receipt`;
+    case 'order':
+      return `/orders/${hit.id}`;
+    case 'alteration':
+      return `/alterations/${hit.id}`;
+  }
+}

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -797,6 +797,30 @@ export type Database = {
       next_receipt_no: { Args: Record<string, never>; Returns: string };
       count_active_users: { Args: Record<string, never>; Returns: number };
       next_reference: { Args: { p_prefix: string }; Returns: string };
+      search_transactions: {
+        Args: {
+          p_term: string | null;
+          p_kinds?: string[] | null;
+          p_stage?: string | null;
+          p_from?: string | null;
+          p_to?: string | null;
+          p_limit?: number;
+          p_offset?: number;
+        };
+        Returns: {
+          kind: string;
+          id: string;
+          reference: string;
+          occurred_at: string;
+          customer_name: string;
+          student_name: string | null;
+          phone: string | null;
+          status: string | null;
+          amount: number;
+          match_rank: number;
+          total_count: number;
+        }[];
+      };
       order_status_rank: { Args: { s: OrderStatus }; Returns: number };
       alteration_status_rank: { Args: { s: AlterationStatus }; Returns: number };
       collect_order_lines: {

--- a/supabase/migrations/20260101002400_unaccent.sql
+++ b/supabase/migrations/20260101002400_unaccent.sql
@@ -1,0 +1,13 @@
+-- Accent-insensitive matching for the unified search (A-FR-7.6).
+--
+-- The two searches that actually fail at this counter are accents and partial
+-- names: a parent typed as "Thérèse" is looked up as "therese", and "Ateba"
+-- should find "Jean Ateba". unaccent plus ILIKE covers both, predictably.
+--
+-- pg_trgm was the alternative. It adds typo tolerance and similarity ranking,
+-- but brings a threshold that has to be tuned and produces matches nobody
+-- asked for -- a knob whose right value nobody at the shop could know.
+--
+-- Installed into the extensions schema rather than public, which is where
+-- Supabase keeps them and keeps public for this project's own objects.
+create extension if not exists unaccent with schema extensions;

--- a/supabase/migrations/20260101002500_search_transactions.sql
+++ b/supabase/migrations/20260101002500_search_transactions.sql
@@ -1,0 +1,187 @@
+-- Unified search across sales, orders and alterations (A-FR-7.6).
+--
+-- "Most parents arrive without their paper receipt", so the reference number is
+-- the least likely thing anyone will have. One box takes a reference, a
+-- student's name, a parent's name or a phone number and finds the transaction
+-- whichever of the three it is.
+--
+-- A single function rather than three queries merged in the application,
+-- because the issue asks for pagination: merging in JavaScript would mean
+-- fetching every matching row from all three tables in order to sort and count
+-- them, which is precisely what pagination exists to avoid.
+--
+-- SECURITY INVOKER -- the default, and load-bearing here. The search runs as
+-- the caller, so RLS decides what it can see: a seller finds their own
+-- transactions and an oversight role finds everything, with no permission
+-- logic repeated in this function.
+
+create or replace function public.search_transactions(
+  p_term   text,
+  p_kinds  text[]    default null,   -- null = all three
+  p_stage  text      default null,   -- waiting | in_progress | ready
+  p_from   date      default null,
+  p_to     date      default null,
+  p_limit  integer   default 20,
+  p_offset integer   default 0
+)
+returns table (
+  kind          text,
+  id            uuid,
+  reference     text,
+  occurred_at   timestamptz,
+  customer_name text,
+  student_name  text,
+  phone         text,
+  status        text,
+  amount        numeric,
+  match_rank    integer,
+  total_count   bigint
+)
+language sql
+stable
+set search_path = public, extensions, pg_temp
+as $fn$
+with
+  -- Digits only, so "+237 6 77 00 00 00" finds "677000000". Nobody types a
+  -- Cameroonian number the same way twice.
+  needle as (
+    select
+      nullif(btrim(coalesce(p_term, '')), '')                as raw,
+      unaccent(lower(btrim(coalesce(p_term, ''))))           as folded,
+      nullif(regexp_replace(coalesce(p_term, ''), '\D', '', 'g'), '') as digits
+  ),
+
+  rows as (
+    -- ------------------------------------------------------------- sales
+    select
+      'sale'::text                                   as kind,
+      s.id,
+      s.receipt_no                                   as reference,
+      s.sold_at                                      as occurred_at,
+      s.customer_name,
+      s.student_name,
+      s.phone,
+      null::text                                     as status,
+      s.total                                        as amount,
+      -- A reference match beats a name match: typing a receipt number means
+      -- you want that record, not everything that mentions it.
+      case when n.raw is not null and s.receipt_no ilike '%' || n.raw || '%'
+           then 0 else 1 end                         as match_rank
+    from public.sales s cross join needle n
+    where (p_kinds is null or 'sale' = any (p_kinds))
+      and (p_from is null or s.sold_at >= p_from)
+      and (p_to   is null or s.sold_at < (p_to + 1))
+      -- A sale has no status, so a stage filter can only exclude it.
+      and p_stage is null
+      and (
+        n.raw is null
+        or s.receipt_no ilike '%' || n.raw || '%'
+        or unaccent(lower(s.customer_name)) like '%' || n.folded || '%'
+        or unaccent(lower(coalesce(s.student_name, ''))) like '%' || n.folded || '%'
+        or (n.digits is not null
+            and regexp_replace(coalesce(s.phone, ''), '\D', '', 'g') like '%' || n.digits || '%')
+      )
+
+    union all
+
+    -- ------------------------------------------------------------ orders
+    select
+      'order'::text,
+      o.id,
+      o.order_no,
+      o.ordered_at,
+      o.customer_name,
+      o.student_name,
+      o.phone,
+      -- The least advanced line still live: an order with one shirt ready and
+      -- one in production is in production, which is the work still to do.
+      (
+        select oi.status::text
+        from public.order_items oi
+        where oi.order_id = o.id
+          and oi.status is not null
+          and oi.status <> 'cancelled'
+        order by public.order_status_rank(oi.status)
+        limit 1
+      ),
+      o.total,
+      case when n.raw is not null and o.order_no ilike '%' || n.raw || '%'
+           then 0 else 1 end
+    from public.orders o cross join needle n
+    where (p_kinds is null or 'order' = any (p_kinds))
+      and (p_from is null or o.ordered_at >= p_from)
+      and (p_to   is null or o.ordered_at < (p_to + 1))
+      and (
+        p_stage is null
+        or exists (
+          select 1 from public.order_items oi
+          where oi.order_id = o.id
+            and case oi.status
+                  when 'ordered'       then 'waiting'
+                  when 'in_production' then 'in_progress'
+                  when 'ready'         then 'ready'
+                end = p_stage
+        )
+      )
+      and (
+        n.raw is null
+        or o.order_no ilike '%' || n.raw || '%'
+        or unaccent(lower(o.customer_name)) like '%' || n.folded || '%'
+        or unaccent(lower(coalesce(o.student_name, ''))) like '%' || n.folded || '%'
+        or (n.digits is not null
+            and regexp_replace(coalesce(o.phone, ''), '\D', '', 'g') like '%' || n.digits || '%')
+      )
+
+    union all
+
+    -- ------------------------------------------------------- alterations
+    select
+      'alteration'::text,
+      a.id,
+      a.alteration_no,
+      a.received_at,
+      a.customer_name,
+      a.student_name,
+      a.phone,
+      a.status::text,
+      a.charge,
+      case when n.raw is not null and a.alteration_no ilike '%' || n.raw || '%'
+           then 0 else 1 end
+    from public.alterations a cross join needle n
+    where (p_kinds is null or 'alteration' = any (p_kinds))
+      and (p_from is null or a.received_at >= p_from)
+      and (p_to   is null or a.received_at < (p_to + 1))
+      and (
+        p_stage is null
+        or case a.status
+             when 'received'    then 'waiting'
+             when 'in_progress' then 'in_progress'
+             when 'ready'       then 'ready'
+           end = p_stage
+      )
+      and (
+        n.raw is null
+        or a.alteration_no ilike '%' || n.raw || '%'
+        or unaccent(lower(a.customer_name)) like '%' || n.folded || '%'
+        or unaccent(lower(coalesce(a.student_name, ''))) like '%' || n.folded || '%'
+        or (n.digits is not null
+            and regexp_replace(coalesce(a.phone, ''), '\D', '', 'g') like '%' || n.digits || '%')
+      )
+  )
+
+select
+  kind, id, reference, occurred_at, customer_name, student_name, phone,
+  status, amount, match_rank,
+  -- Counted over the whole result set before the window is taken, so the page
+  -- can say "12 results" while showing 20 of them.
+  count(*) over () as total_count
+from rows
+-- References first, then newest: a parent at the counter is nearly always
+-- asking about something recent.
+order by match_rank, occurred_at desc
+limit greatest(1, least(coalesce(p_limit, 20), 100))
+offset greatest(0, coalesce(p_offset, 0));
+$fn$;
+
+revoke all on function public.search_transactions(text, text[], text, date, date, integer, integer) from public;
+grant execute on function public.search_transactions(text, text[], text, date, date, integer, integer) to authenticated;

--- a/supabase/migrations/rollback/20260101002400_unaccent_down.sql
+++ b/supabase/migrations/rollback/20260101002400_unaccent_down.sql
@@ -1,0 +1,8 @@
+-- Rollback for 20260101002400_unaccent.sql.
+--
+-- MANUAL ONLY -- see supabase/README.md. Run
+-- 20260101002500_search_transactions_down.sql FIRST: that function calls
+-- unaccent(), so dropping the extension while it exists breaks the search
+-- rather than removing it.
+
+drop extension if exists unaccent;

--- a/supabase/migrations/rollback/20260101002500_search_transactions_down.sql
+++ b/supabase/migrations/rollback/20260101002500_search_transactions_down.sql
@@ -1,0 +1,10 @@
+-- Rollback for 20260101002500_search_transactions.sql.
+--
+-- MANUAL ONLY -- see supabase/README.md. Run this BEFORE
+-- 20260101002400_unaccent_down.sql.
+--
+-- Nothing is lost but the ability to search: this function only reads. The
+-- screens that call it will fail, which is the intended signal that the search
+-- is gone rather than merely returning nothing.
+
+drop function if exists public.search_transactions(text, text[], text, date, date, integer, integer);


### PR DESCRIPTION
Closes #27

Requirement: A-FR-7.6

## What this does
Most parents arrive without their paper receipt, so the reference number is the
least likely thing anyone will have. One box takes whatever they *do* have — a
parent's name, a student's name, a phone number, or the reference if they kept it
— and finds the transaction whichever of the three kinds it is.

The search box has sat in the top bar of every screen since the shell was written,
raising a toast and doing nothing. It now goes somewhere, and its placeholder
message is deleted rather than left as a string nobody can reach.

## Decisions worth reviewing
- **One database function, not three merged queries.** The issue asks for
  pagination; merging in JS would mean fetching every match from all three tables
  to sort and count them — exactly what pagination avoids. `SECURITY INVOKER`, so
  RLS decides what each caller finds.
- **`unaccent` + `ILIKE`, not `pg_trgm`.** The two failures that actually happen
  are accents and partial names. Trigram matching adds typo tolerance but brings a
  similarity threshold whose right value nobody at the shop could know.
- **Phone matching strips punctuation from both sides** — nobody types a
  Cameroonian number the same way twice.
- **A reference match sorts first**; otherwise newest first.
- **The status filter narrows only the kinds that have a status.** A sale simply
  happened, so choosing a stage excludes sales rather than pretending otherwise.
- **Deselecting the last type filter means "all", not "none"** — an empty result
  from an empty filter reads as "nothing found", which is a lie.
- **The whole query lives in the URL**, so a search survives a reload and can be
  sent to a colleague.

## Verified against real data
Reference, partial parent name, student surname, case-insensitivity, bare and
spaced phone numbers, each type filter, the stage filter excluding sales, both
date bounds, and pagination. Accent folding verified with a seeded record:
`therese`, `Thérèse`, `ebode` and `zoe` all find **Thérèse Ébodé**.