### PR TITLE
PR/feat(security): Supabase project + schema + Row level security

### DIFF
--- a/supabase/migrations/20260101002600_insert_only_grants.sql
+++ b/supabase/migrations/20260101002600_insert_only_grants.sql
@@ -1,0 +1,30 @@
+-- Grant-level insert-only enforcement on the append-only ledgers (spec A-11,
+-- and the P0 "insert-only at the database level" rule).
+--
+-- These three tables are already append-only through RLS -- none of them has an
+-- UPDATE or DELETE policy, so PostgREST already refuses an edit from a signed-in
+-- user (04_stock.sql, 06_audit_log.sql, 07_product_prices.sql). This migration
+-- adds the second, coarser lock the acceptance criterion asks for: revoke the
+-- privilege itself, so a direct UPDATE/DELETE is refused by the grant system
+-- before RLS is even consulted. Defense in depth -- a future policy mistake
+-- cannot re-open an edit path that the role no longer holds the privilege for.
+--
+-- Scope is deliberately just the ledgers that are ALREADY append-only:
+--   * audit_log             -- the tamper-evidence record itself
+--   * stock_movements       -- corrections are compensating 'adjustment' rows
+--   * product_prices_history -- price history, never rewritten
+--
+-- NOT applied to sales, orders, order_items or alterations: those rely on
+-- in-place UPDATE by design -- super_admin sale amendment (03_sales.sql) and the
+-- order/alteration status workflows -- so a blanket revoke there would break
+-- shipped, intended behaviour. Making them append-only would be a schema
+-- re-architecture, not a grant tweak, and is out of scope here.
+--
+-- INSERT and SELECT are untouched: the app still records and reads these tables.
+-- Writes that must always succeed (audit_log via logAudit, batch stock movements)
+-- go through the service role or SECURITY DEFINER functions, which own the tables
+-- and are unaffected by revokes on the authenticated/anon roles.
+
+revoke update, delete on public.audit_log              from authenticated, anon;
+revoke update, delete on public.stock_movements        from authenticated, anon;
+revoke update, delete on public.product_prices_history from authenticated, anon;

--- a/supabase/migrations/rollback/20260101002600_insert_only_grants_down.sql
+++ b/supabase/migrations/rollback/20260101002600_insert_only_grants_down.sql
@@ -1,0 +1,13 @@
+-- Rollback for 20260101002600_insert_only_grants.sql.
+--
+-- MANUAL ONLY -- apply by hand (psql or the SQL editor), never with `db push`
+-- or `db reset`. See supabase/README.md.
+--
+-- Restores the UPDATE/DELETE privileges the forward migration revoked. RLS is
+-- unchanged and still refuses edits (no UPDATE/DELETE policy exists on these
+-- tables), so re-granting the privilege does NOT actually re-open an edit path
+-- for a signed-in user -- it merely returns the grant matrix to its prior state.
+
+grant update, delete on public.audit_log              to authenticated, anon;
+grant update, delete on public.stock_movements        to authenticated, anon;
+grant update, delete on public.product_prices_history to authenticated, anon;


### PR DESCRIPTION
## Summary

Closes the P0 "insert-only at the database level" requirement for the append-only ledgers. These tables were already append-only via RLS (no UPDATE/DELETE policy), but the acceptance criterion asks for the privilege itself to be revoked from the application role — so a direct edit is refused by the grant system *before* RLS is consulted (defense in depth: a future policy mistake can't re-open an edit path the role no longer holds).

Scope was confirmed with the maintainer: only the tables that are *already* append-only are hardened. `sales`/`orders`/`alterations` are deliberately left alone — they rely on in-place UPDATE by design (super_admin sale amendment, order/alteration status workflows), so a blanket revoke there would break shipped behavior. Money stays `numeric(12,2)` (values are already whole FCFA, enforced by constraints + the price-integrity trigger).

## Changes

| File | Change |
|---|---|
| `supabase/migrations/20260101002600_insert_only_grants.sql` (new) | `REVOKE UPDATE, DELETE ... FROM authenticated, anon` on `audit_log`, `stock_movements`, `product_prices_history`. INSERT/SELECT untouched. |
| `supabase/migrations/rollback/20260101002600_insert_only_grants_down.sql` (new) | Matching manual rollback (re-grants the privileges; RLS still refuses edits). |

## Acceptance

- **RLS enabled on every table** — already true (every migration ends with `enable row level security`).
- **Anonymous requests rejected** — already true (all policies `to authenticated`, no `anon` policies).
- **Direct UPDATE/DELETE refused by the DB on transaction tables** — now enforced at both grant and RLS level for the three ledgers; deliberately not for `sales`/`orders`/`alterations` (documented exceptions).
- **Schema committed as SQL migration** — already true; this adds the enforcement migration.

## Verification

Not applied against a DB (local Docker unavailable). After `supabase db push`/`db reset`:

```sql
set role authenticated;
update public.audit_log set action = 'x';                  -- ERROR: permission denied for table audit_log
delete from public.stock_movements where true;             -- ERROR: permission denied for table stock_movements
update public.product_prices_history set new_price = 0;     -- ERROR: permission denied
insert into public.audit_log(action) values ('t');         -- still allowed (INSERT not revoked)
reset role;
```

## Notes

- `collections`/`collection_items` are also append-only and could take the same revoke; left out to match the approved three-table scope.
- Writes that must always succeed (audit via `logAudit`, batch stock movements) go through the service role / `SECURITY DEFINER` functions, which own the tables and are unaffected by these revokes.


