### PR TITLE
PR/Transition layer scaffolded

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -3,6 +3,10 @@
     "name": "School Uniform Sales",
     "tagline": "Point of sale for school uniforms"
   },
+  "Common": {
+    "close": "Close",
+    "loading": "Loading"
+  },
   "Nav": {
     "dashboard": "Dashboard",
     "profile": "Profile",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -3,6 +3,10 @@
     "name": "Vente d'uniformes scolaires",
     "tagline": "Point de vente des uniformes scolaires"
   },
+  "Common": {
+    "close": "Fermer",
+    "loading": "Chargement"
+  },
   "Nav": {
     "dashboard": "Tableau de bord",
     "profile": "Profil",

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -2,6 +2,7 @@
 
 import * as React from "react"
 import { Dialog as DialogPrimitive } from "radix-ui"
+import { useTranslations } from "next-intl"
 
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
@@ -55,6 +56,7 @@ function DialogContent({
 }: React.ComponentProps<typeof DialogPrimitive.Content> & {
   showCloseButton?: boolean
 }) {
+  const t = useTranslations("Common")
   return (
     <DialogPortal>
       <DialogOverlay />
@@ -76,7 +78,7 @@ function DialogContent({
             >
               <XIcon
               />
-              <span className="sr-only">Close</span>
+              <span className="sr-only">{t("close")}</span>
             </Button>
           </DialogPrimitive.Close>
         )}
@@ -103,6 +105,7 @@ function DialogFooter({
 }: React.ComponentProps<"div"> & {
   showCloseButton?: boolean
 }) {
+  const t = useTranslations("Common")
   return (
     <div
       data-slot="dialog-footer"
@@ -115,7 +118,7 @@ function DialogFooter({
       {children}
       {showCloseButton && (
         <DialogPrimitive.Close asChild>
-          <Button variant="outline">Close</Button>
+          <Button variant="outline">{t("close")}</Button>
         </DialogPrimitive.Close>
       )}
     </div>

--- a/src/components/ui/spinner.tsx
+++ b/src/components/ui/spinner.tsx
@@ -1,11 +1,15 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
 import { cn } from '@/lib/utils';
 
 /** In-app loading spinner (orange by default). Size via className, e.g. `size-6`. */
 export function Spinner({ className }: { className?: string }) {
+  const t = useTranslations('Common');
   return (
     <span
       role="status"
-      aria-label="Loading"
+      aria-label={t('loading')}
       className={cn(
         'inline-block size-5 animate-spin rounded-full border-2 border-primary/30 border-t-primary',
         className


### PR DESCRIPTION
## Summary

Audit for hardcoded UI strings (i18n "zero hardcoded strings" acceptance). The app was already well-internationalized — forms, pages, panels, and toasts all use `t(...)`. The only real violations were accessibility strings buried in two shared base UI primitives, now fixed.

## Changes

| File | Change |
|---|---|
| `src/components/ui/dialog.tsx` | The sr-only "Close" (rendered on every dialog via the default X button) and the footer "Close" button now use `{t('close')}`. |
| `src/components/ui/spinner.tsx` | `aria-label="Loading"` → `{t('loading')}`; made a client component (renders only inside the `[locale]` provider tree). |
| `messages/en.json`, `messages/fr.json` | New `Common` namespace: `close`, `loading` (Fermer / Chargement). |

## Intentional exceptions (not touched)

- **Bilingual print slips** — `Retiré / Collected`, `Commande / Order`, `Commande annulée / Order cancelled`, `Bon de dépôt / Deposit slip`, `Duplicata / Duplicate` (receipt-print, collection-slip, deposit-slip, duplicate-stamp). Deliberately bilingual by design (documented in `duplicate-stamp.tsx`): a parent holding a physical slip may not share the seller's UI language.
- `brand/school-logo.tsx` `alt` — the school's proper name, correct alt text and not translatable. Flagged, left as-is.

## Verification

- `tsc --noEmit` and `eslint` on changed files clean; both message catalogues parse.
- Same-line and targeted JSX text scans find no remaining hardcoded translatable strings.
- Confirmed `Spinner`/`PageLoader` only render under `NextIntlClientProvider`, so `useTranslations` is always available.

## Acceptance

- Toggle switches every visible label ✓ (including the two a11y strings).
- Zero hardcoded translatable strings ✓ (bilingual slips are the documented exception).
- User input displays as typed, untranslated ✓.

## Walkthrough

1. Open any dialog → the X button's screen-reader label is "Close"; switch to French → "Fermer".
2. Submit a form → spinner `aria-label` is "Loading" / "Chargement" per locale.
3. Print a collection slip → still shows `Retiré / Collected` in both languages (intended).


