### PR TITLE
PR/feat(returns): out-of-policy report, returns in the daily reconciliation, exchange chain (A-FR-8.12 to A-FR-8.14)

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -294,6 +294,7 @@
       "catalogue": { "title": "Catalogue & prices", "desc": "Garments, sizes and prices." },
       "reports": { "title": "Reports & exports", "desc": "Sales figures and Excel exports." },
       "bugReports": {"title": "Bug reports", "desc": "Problems reported from inside the app."},
+      "returns-overrides": "Returns & policy overrides",
       "audit": { "title": "Audit log", "desc": "Every action, filterable by date, user and type." },
       "accounts": { "title": "User accounts", "desc": "Create accounts, reset passwords and set roles." }
     }
@@ -637,6 +638,7 @@
     "errorGeneric": "The policy could not be updated. Nothing was changed."
   },
   "Returns": {
+    "fromExchange": "from an exchange",
     "soldDaysAgo": "Sold {days} days ago.",
     "verdictAllowed": "{condition}: {kind} allowed, within the {window}-day window.",
     "verdictOutside": "{condition}: {kind} is outside the {window}-day window.",
@@ -773,6 +775,18 @@
     "empty": "No sales found for the selected period.",
     "summary": "{count} sales totalling {total}",
     "recon": {
+      "returns": "Returns & exchanges",
+      "overrides": "{count} override(s)",
+      "originalSale": "Original sale",
+      "kind": "Type",
+      "policy": "Policy",
+      "by": "Recorded by",
+      "override": "Override",
+      "withinPolicy": "Within policy",
+      "returnKinds": {
+        "return": "Refund",
+        "exchange": "Exchange"
+      },
       "title": "Daily cash reconciliation",
       "range": "{from} to {to}",
       "export": "Export reconciliation",
@@ -814,6 +828,17 @@
       }
     },
     "suite": {
+      "withinPolicy": "Within policy",
+      "override": "Override",
+      "overrideRate": "{overrides} override(s) out of {total} return(s)",
+      "returnKinds": {
+        "return": "Refund",
+        "exchange": "Exchange"
+      },
+      "conditions": {
+        "unworn": "Unworn",
+        "worn": "Worn"
+      },
       "title": "Reports",
       "subtitle": "Sales, production, orders and audit — export to Excel or PDF.",
       "report": "Report",
@@ -837,6 +862,18 @@
         "audit": "Audit log"
       },
       "col": {
+        "reference": "Reference",
+        "sale": "Original sale",
+        "kind": "Type",
+        "condition": "Condition",
+        "elapsedDays": "Days elapsed",
+        "windowDays": "Window (days)",
+        "verdict": "Policy",
+        "overrideReason": "Override reason",
+        "refund": "Refunded",
+        "collected": "Collected",
+        "method": "Method",
+        "by": "Recorded by",
         "date": "Date",
         "transactions": "Transactions",
         "gross": "Gross",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -294,6 +294,7 @@
       "catalogue": { "title": "Catalogue et prix", "desc": "V\u00eatements, tailles et prix." },
       "reports": { "title": "Rapports et exports", "desc": "Chiffres de vente et exports Excel." },
       "bugReports": {"title": "Signalements", "desc": "Problèmes signalés depuis l’application."},
+      "returns-overrides": "Retours et dérogations",
       "audit": { "title": "Journal d'audit", "desc": "Chaque action, filtrable par date, utilisateur et type." },
       "accounts": { "title": "Comptes utilisateurs", "desc": "Cr\u00e9er des comptes, r\u00e9initialiser les mots de passe et d\u00e9finir les r\u00f4les." }
     }
@@ -637,6 +638,7 @@
     "errorGeneric": "La politique n'a pas pu être mise à jour. Rien n'a été modifié."
   },
   "Returns": {
+    "fromExchange": "issu d’un échange",
     "soldDaysAgo": "Vendu il y a {days} jours.",
     "verdictAllowed": "{condition} : {kind} autorisé, dans le délai de {window} jours.",
     "verdictOutside": "{condition} : {kind} hors du délai de {window} jours.",
@@ -773,6 +775,18 @@
     "empty": "Aucune vente pour la p\u00e9riode s\u00e9lectionn\u00e9e.",
     "summary": "{count} ventes pour un total de {total}",
     "recon": {
+      "returns": "Retours et échanges",
+      "overrides": "{count} dérogation(s)",
+      "originalSale": "Vente d’origine",
+      "kind": "Type",
+      "policy": "Politique",
+      "by": "Saisi par",
+      "override": "Dérogation",
+      "withinPolicy": "Dans les délais",
+      "returnKinds": {
+        "return": "Remboursement",
+        "exchange": "Échange"
+      },
       "title": "Rapprochement de caisse quotidien",
       "range": "Du {from} au {to}",
       "export": "Exporter le rapprochement",
@@ -814,6 +828,17 @@
       }
     },
     "suite": {
+      "withinPolicy": "Dans les délais",
+      "override": "Dérogation",
+      "overrideRate": "{overrides} dérogation(s) sur {total} retour(s)",
+      "returnKinds": {
+        "return": "Remboursement",
+        "exchange": "Échange"
+      },
+      "conditions": {
+        "unworn": "Non porté",
+        "worn": "Porté"
+      },
       "title": "Rapports",
       "subtitle": "Ventes, production, commandes et audit — export Excel ou PDF.",
       "report": "Rapport",
@@ -837,6 +862,18 @@
         "audit": "Journal d'audit"
       },
       "col": {
+        "reference": "Référence",
+        "sale": "Vente d’origine",
+        "kind": "Type",
+        "condition": "État",
+        "elapsedDays": "Jours écoulés",
+        "windowDays": "Délai (jours)",
+        "verdict": "Politique",
+        "overrideReason": "Motif de la dérogation",
+        "refund": "Remboursé",
+        "collected": "Encaissé",
+        "method": "Mode",
+        "by": "Saisi par",
         "date": "Date",
         "transactions": "Transactions",
         "gross": "Brut",

--- a/src/actions/reports.ts
+++ b/src/actions/reports.ts
@@ -64,6 +64,30 @@ export type DailyReconciliation = {
   undeliveredOrdersTotal: number;
   byReceiver: { name: string; total: number; count: number }[];
   discounts: { receiptNo: string; amount: number; reason: string | null }[];
+  /**
+   * Returns and exchanges in the period (A-FR-8.12).
+   *
+   * Kept apart from `cancellations`, which are cancelled ORDER lines. Both move
+   * money back to a parent, but they answer different questions and the
+   * administration reconciles them separately.
+   */
+  returns: {
+    returnNo: string;
+    saleReceiptNo: string;
+    kind: 'return' | 'exchange';
+    /** What went back to the parent. Zero on an even swap or a top-up. */
+    refund: number;
+    refundMethod: PaymentMethod | null;
+    /** What the parent paid when the replacement cost more. */
+    collected: number;
+    collectedMethod: PaymentMethod | null;
+    withinPolicy: boolean | null;
+    overrideReason: string | null;
+    seller: string | null;
+    at: string;
+  }[];
+  /** How many of the period's returns were recorded outside policy. */
+  overrideCount: number;
   cancellations: {
     orderNo: string;
     description: string;
@@ -105,7 +129,7 @@ export async function getDailyReconciliation(
   const fromIso = new Date(`${from}T00:00:00`).toISOString();
   const toIso = new Date(`${to}T23:59:59.999`).toISOString();
 
-  const [salesRes, cancelRes, orderRes] = await Promise.all([
+  const [salesRes, cancelRes, orderRes, returnRes] = await Promise.all([
     admin
       .from('sales')
       .select(
@@ -133,12 +157,24 @@ export async function getDailyReconciliation(
       .from('orders')
       .select('id, ordered_at, items:order_items ( line_total, status )')
       .gte('ordered_at', fromIso)
-      .lte('ordered_at', toIso)
+      .lte('ordered_at', toIso),
+    admin
+      .from('returns')
+      .select(
+        `return_no, kind, returned_at, refund_amount, refund_method,
+         collected_amount, collected_method, within_policy, override_reason,
+         sale:sales!returns_sale_id_fkey ( receipt_no ),
+         seller:profiles!returns_seller_id_fkey ( full_name )`
+      )
+      .gte('returned_at', fromIso)
+      .lte('returned_at', toIso)
+      .order('returned_at', { ascending: true })
   ]);
 
   const sales = salesRes.data ?? [];
   const cancels = cancelRes.data ?? [];
   const orders = orderRes.data ?? [];
+  const returnRows = returnRes.data ?? [];
 
   // --- sales-side aggregates ------------------------------------------------
   const byMethod = tallyByMethod(
@@ -173,11 +209,51 @@ export async function getDailyReconciliation(
     .filter((s) => num(s.discount) > 0)
     .map((s) => ({ receiptNo: s.receipt_no, amount: num(s.discount), reason: s.discount_reason }));
 
-  // --- refunds / cancellations (order-line cancellations) -------------------
-  const refundsByMethod = tallyByMethod(
-    cancels
+  // --- returns and exchanges (A-FR-8.12) ------------------------------------
+  const returns = returnRows.map((r) => {
+    const sale = Array.isArray(r.sale) ? r.sale[0] : r.sale;
+    return {
+      returnNo: r.return_no,
+      saleReceiptNo: (sale as { receipt_no?: string } | null)?.receipt_no ?? '—',
+      kind: r.kind,
+      refund: num(r.refund_amount),
+      refundMethod: r.refund_method,
+      collected: num(r.collected_amount),
+      collectedMethod: r.collected_method,
+      withinPolicy: r.within_policy,
+      overrideReason: r.override_reason,
+      seller: name(r.seller),
+      at: r.returned_at
+    };
+  });
+
+  // `within_policy` is null only for returns recorded before the policy engine
+  // existed. Those are not overrides -- no rule was set aside, there was no
+  // rule -- so they are counted as neither.
+  const overrideCount = returns.filter((r) => r.withinPolicy === false).length;
+
+  // --- refunds ---------------------------------------------------------------
+  //
+  // Two sources, and until now only the first was counted: cancelled order
+  // lines. A cash refund given for a RETURN never reduced netCashInBox, so the
+  // drawer could not balance on any day a garment came back. A-FR-8.12 asks for
+  // returns in the daily report; this is the arithmetic half of that.
+  const refundsByMethod = tallyByMethod([
+    ...cancels
       .filter((c) => c.refund_method)
-      .map((c) => ({ method: c.refund_method as PaymentMethod, amount: num(c.line_total) }))
+      .map((c) => ({ method: c.refund_method as PaymentMethod, amount: num(c.line_total) })),
+    ...returns
+      .filter((r) => r.refund > 0 && r.refundMethod)
+      .map((r) => ({ method: r.refundMethod as PaymentMethod, amount: r.refund }))
+  ]);
+
+  // An exchange for a dearer garment takes money IN. It is not a sale -- no
+  // sales row exists for it -- so without this the till is short by every
+  // top-up collected in the period.
+  const collectedOnExchanges = tallyByMethod(
+    returns
+      .filter((r) => r.collected > 0 && r.collectedMethod)
+      .map((r) => ({ method: r.collectedMethod as PaymentMethod, amount: r.collected }))
   );
 
   const cancellations = cancels.map((c) => {
@@ -210,7 +286,12 @@ export async function getDailyReconciliation(
     netCollected,
     byMethod,
     refundsByMethod,
-    netCashInBox: methodTotal(byMethod, 'cash') - methodTotal(refundsByMethod, 'cash'),
+    // Cash sold, plus cash taken as an exchange top-up, less cash refunded --
+    // whether that refund came from a cancelled order line or a return.
+    netCashInBox:
+      methodTotal(byMethod, 'cash')
+      + methodTotal(collectedOnExchanges, 'cash')
+      - methodTotal(refundsByMethod, 'cash'),
     mobileMoney: {
       total: mobileMoneyTx.reduce((sum, t) => sum + t.amount, 0),
       transactions: mobileMoneyTx
@@ -220,6 +301,8 @@ export async function getDailyReconciliation(
       (a, b) => b.total - a.total
     ),
     discounts,
+    returns,
+    overrideCount,
     cancellations
   };
 }
@@ -597,6 +680,97 @@ export async function getReport(
     }
 
     // ---------------------------------------------------------------- audit
+    case 'returns-overrides': {
+      // A-FR-8.12: "how often the rule is being set aside, and by whom".
+      //
+      // Every return in the period, not only the overrides. The count of
+      // overrides on its own is unreadable -- three is alarming out of four and
+      // unremarkable out of ninety -- so the denominator is in the table and
+      // the totals row carries the rate.
+      const { data } = await admin
+        .from('returns')
+        .select(
+          `return_no, kind, returned_at, condition, elapsed_days,
+           policy_window_days, within_policy, override_reason, reason,
+           refund_amount, refund_method, collected_amount, collected_method,
+           sale:sales!returns_sale_id_fkey ( receipt_no ),
+           seller:profiles!returns_seller_id_fkey ( full_name ),
+           recordedBy:profiles!returns_recorded_by_fkey ( full_name )`
+        )
+        .gte('returned_at', fromIso)
+        .lte('returned_at', toIso)
+        // Overrides first: the rows this report exists for should not be
+        // somewhere in the middle of a long list.
+        .order('within_policy', { ascending: true, nullsFirst: false })
+        .order('returned_at', { ascending: false });
+
+      const rows: ReportRow[] = (data ?? []).map((r) => {
+        const sale = Array.isArray(r.sale) ? r.sale[0] : r.sale;
+        return {
+          reference: r.return_no,
+          sale: (sale as { receipt_no?: string } | null)?.receipt_no ?? '—',
+          kind: t(`suite.returnKinds.${r.kind}`),
+          condition: t(`suite.conditions.${r.condition}`),
+          elapsed: r.elapsed_days,
+          window: r.policy_window_days,
+          // null is not an override: those rows predate the policy engine, so
+          // no rule was set aside because there was no rule.
+          verdict:
+            r.within_policy === null
+              ? '—'
+              : r.within_policy
+                ? t('suite.withinPolicy')
+                : t('suite.override'),
+          // The reason for going outside policy, which is a different field
+          // from the ordinary reason every return carries.
+          overrideReason: r.override_reason ?? '—',
+          reason: r.reason,
+          refund: num(r.refund_amount),
+          collected: num(r.collected_amount),
+          method:
+            r.refund_amount > 0 && r.refund_method
+              ? methodLabel(r.refund_method)
+              : r.collected_amount > 0 && r.collected_method
+                ? methodLabel(r.collected_method)
+                : '—',
+          by: name(r.recordedBy) ?? name(r.seller) ?? '—',
+          when: r.returned_at
+        };
+      });
+
+      const overrides = (data ?? []).filter((r) => r.within_policy === false).length;
+
+      return {
+        key,
+        title,
+        columns: [
+          { key: 'reference', label: c('reference'), type: 'text' },
+          { key: 'sale', label: c('sale'), type: 'text' },
+          { key: 'kind', label: c('kind'), type: 'text' },
+          { key: 'condition', label: c('condition'), type: 'text' },
+          { key: 'elapsed', label: c('elapsedDays'), type: 'number' },
+          { key: 'window', label: c('windowDays'), type: 'number' },
+          { key: 'verdict', label: c('verdict'), type: 'text' },
+          { key: 'overrideReason', label: c('overrideReason'), type: 'text' },
+          { key: 'reason', label: c('reason'), type: 'text' },
+          { key: 'refund', label: c('refund'), type: 'money' },
+          { key: 'collected', label: c('collected'), type: 'money' },
+          { key: 'method', label: c('method'), type: 'text' },
+          { key: 'by', label: c('by'), type: 'text' },
+          { key: 'when', label: c('when'), type: 'datetime' }
+        ],
+        rows,
+        totals: {
+          reference: t('suite.overrideRate', {
+            overrides,
+            total: rows.length
+          }),
+          refund: rows.reduce((sum, r) => sum + Number(r.refund ?? 0), 0),
+          collected: rows.reduce((sum, r) => sum + Number(r.collected ?? 0), 0)
+        }
+      };
+    }
+
     case 'audit': {
       const { data } = await admin
         .from('audit_log')

--- a/src/actions/returns.ts
+++ b/src/actions/returns.ts
@@ -57,8 +57,11 @@ export async function recordReturn(input: ReturnInput): Promise<RecordReturnResu
       p_reason: value.reason,
       p_condition: value.condition,
       // Ids and quantities only. Prices are the server's to decide.
+      // Each line names exactly one source: the sale line it was bought on, or
+      // the outgoing line it was received on in an earlier exchange.
       p_in_items: value.returnedItems.map((line) => ({
         sale_item_id: line.saleItemId,
+        source_return_item_id: line.sourceReturnItemId,
         quantity: line.quantity
       })),
       p_out_items: value.outgoingItems.map((line) => ({
@@ -128,32 +131,63 @@ export async function getSaleForReturn(saleId: string) {
 
   if (!sale) return null;
 
-  const lineIds = (sale.items ?? []).map((item) => item.id);
-  const alreadyReturned = new Map<string, number>();
+  // Everything already handed over against this sale in an earlier exchange
+  // (A-FR-8.13). These are returnable too: a parent who swapped M for L and
+  // found L wrong must be able to bring L back, judged against the ORIGINAL
+  // sale date. Reading only sale_items would leave them stuck on day one.
+  const { data: chainRows } = await supabase
+    .from('return_items')
+    .select('id, direction, sale_item_id, source_return_item_id, product_id, description, size, unit_price, quantity, returns!inner ( sale_id )')
+    .eq('returns.sale_id', saleId);
 
-  if (lineIds.length > 0) {
-    const { data: priorLines } = await supabase
-      .from('return_items')
-      .select('sale_item_id, quantity')
-      .eq('direction', 'in')
-      .in('sale_item_id', lineIds);
+  const chain = chainRows ?? [];
 
-    for (const line of priorLines ?? []) {
-      if (!line.sale_item_id) continue;
-      alreadyReturned.set(
-        line.sale_item_id,
-        (alreadyReturned.get(line.sale_item_id) ?? 0) + line.quantity
-      );
-    }
+  // How much has come back against each source, whichever kind it is.
+  const returned = new Map<string, number>();
+  for (const line of chain) {
+    if (line.direction !== 'in') continue;
+    const key = line.sale_item_id ?? line.source_return_item_id;
+    if (key) returned.set(key, (returned.get(key) ?? 0) + line.quantity);
   }
 
-  return {
-    ...sale,
-    items: (sale.items ?? []).map((item) => {
-      const returned = alreadyReturned.get(item.id) ?? 0;
-      return { ...item, returned, returnable: item.quantity - returned };
-    })
-  };
+  const bought = (sale.items ?? []).map((item) => {
+    const back = returned.get(item.id) ?? 0;
+    return {
+      key: item.id,
+      saleItemId: item.id as string | null,
+      sourceReturnItemId: null as string | null,
+      product_id: item.product_id,
+      description: item.description,
+      size: item.size,
+      unit_price: item.unit_price,
+      quantity: item.quantity,
+      returned: back,
+      returnable: item.quantity - back,
+      /** Distinguishes a garment bought outright from one received in a swap. */
+      viaExchange: false
+    };
+  });
+
+  const received = chain
+    .filter((line) => line.direction === 'out')
+    .map((line) => {
+      const back = returned.get(line.id) ?? 0;
+      return {
+        key: line.id,
+        saleItemId: null as string | null,
+        sourceReturnItemId: line.id as string | null,
+        product_id: line.product_id,
+        description: line.description,
+        size: line.size,
+        unit_price: line.unit_price,
+        quantity: line.quantity,
+        returned: back,
+        returnable: line.quantity - back,
+        viaExchange: true
+      };
+    });
+
+  return { ...sale, items: [...bought, ...received] };
 }
 
 /** Every return and exchange against one sale, for the sale's own page. */

--- a/src/components/forms/return-form.tsx
+++ b/src/components/forms/return-form.tsx
@@ -29,7 +29,12 @@ import {
 } from '@/lib/validation/return-schema';
 
 type SaleLine = {
-  id: string;
+  /** Stable id for this row, whichever kind of source it is. */
+  key: string;
+  /** Set when the garment was bought outright. */
+  saleItemId: string | null;
+  /** Set when it was received in an earlier exchange (A-FR-8.13). */
+  sourceReturnItemId: string | null;
   description: string;
   size: string | null;
   unit_price: number;
@@ -38,6 +43,8 @@ type SaleLine = {
   returned: number;
   /** What is still returnable. Zero means this line is spent. */
   returnable: number;
+  /** Marked in the list, so the seller knows which garment they are handling. */
+  viaExchange: boolean;
 };
 
 type Product = {
@@ -119,7 +126,7 @@ export function ReturnForm({
   const valueIn = useMemo(
     () =>
       lines.reduce(
-        (sum, line) => sum + (returning[line.id] ?? 0) * Number(line.unit_price),
+        (sum, line) => sum + (returning[line.key] ?? 0) * Number(line.unit_price),
         0
       ),
     [lines, returning]
@@ -153,7 +160,7 @@ export function ReturnForm({
     // independently -- this is the version that stops the seller before they
     // have typed a whole transaction that cannot be saved.
     const quantity = Math.max(0, Math.min(raw, line.returnable));
-    setReturning((current) => ({ ...current, [line.id]: quantity }));
+    setReturning((current) => ({ ...current, [line.key]: quantity }));
   }
 
   function submit() {
@@ -166,9 +173,16 @@ export function ReturnForm({
           kind,
           reason,
           condition,
-          returnedItems: Object.entries(returning)
-            .filter(([, quantity]) => quantity > 0)
-            .map(([saleItemId, quantity]) => ({ saleItemId, quantity })),
+          // Each chosen row carries its own source, so a garment received in an
+          // exchange comes back referencing the outgoing line it was handed
+          // over on rather than a sale line it never had.
+          returnedItems: lines
+            .filter((line) => (returning[line.key] ?? 0) > 0)
+            .map((line) => ({
+              saleItemId: line.saleItemId,
+              sourceReturnItemId: line.sourceReturnItemId,
+              quantity: returning[line.key]
+            })),
           outgoingItems:
             kind === 'exchange'
               ? outgoing
@@ -326,7 +340,7 @@ export function ReturnForm({
           ) : (
             returnable.map((line) => (
               <div
-                key={line.id}
+                key={line.key}
                 className="flex flex-wrap items-center gap-3 border-b pb-3 last:border-0 last:pb-0"
               >
                 <div className="min-w-0 flex-1">
@@ -334,6 +348,14 @@ export function ReturnForm({
                     {line.description}
                     {line.size ? (
                       <span className="text-muted-foreground"> ({line.size})</span>
+                    ) : null}
+                    {/* Says where this garment came from. Without it, two rows
+                        for the same product -- the one bought and the one
+                        swapped into -- are indistinguishable. */}
+                    {line.viaExchange ? (
+                      <span className="ml-2 rounded bg-muted px-1.5 py-0.5 text-[0.65rem] font-normal">
+                        {t('fromExchange')}
+                      </span>
                     ) : null}
                   </p>
                   <p className="text-xs text-muted-foreground">
@@ -345,15 +367,15 @@ export function ReturnForm({
                   </p>
                 </div>
                 <div className="flex items-center gap-2">
-                  <Label htmlFor={`qty-${line.id}`} className="text-xs">
+                  <Label htmlFor={`qty-${line.key}`} className="text-xs">
                     {t('quantityBack')}
                   </Label>
                   <Input
-                    id={`qty-${line.id}`}
+                    id={`qty-${line.key}`}
                     type="number"
                     min={0}
                     max={line.returnable}
-                    value={returning[line.id] ?? 0}
+                    value={returning[line.key] ?? 0}
                     onChange={(event) =>
                       setQuantity(line, Number(event.target.value) || 0)
                     }

--- a/src/components/reports/daily-reconciliation.tsx
+++ b/src/components/reports/daily-reconciliation.tsx
@@ -1,6 +1,7 @@
 import { getTranslations } from 'next-intl/server';
 import { BanknoteIcon, SmartphoneIcon, TriangleAlertIcon } from 'lucide-react';
 import type { DailyReconciliation as Recon, MethodTotal } from '@/actions/reports';
+import { Badge } from '@/components/ui/badge';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import {
   Table,
@@ -252,6 +253,82 @@ export async function DailyReconciliation({
       </Card>
 
       {/* Cancellations -- shown separately, never in revenue */}
+      {/* Returns and exchanges (A-FR-8.12). Its own card rather than a column
+          in Cancellations: both move money back to a parent, but a cancelled
+          order line and a returned garment are reconciled separately, and the
+          override flag only means something here. */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex flex-wrap items-center gap-2 text-base">
+            {t('recon.returns')}
+            {/* The headline number the administration is looking for: how often
+                the rule was set aside in this period. Shown even when zero,
+                because "none" is the answer they want most days. */}
+            <Badge variant={data.overrideCount > 0 ? 'destructive' : 'secondary'}>
+              {t('recon.overrides', { count: data.overrideCount })}
+            </Badge>
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="overflow-x-auto">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>{t('recon.reference')}</TableHead>
+                  <TableHead>{t('recon.originalSale')}</TableHead>
+                  <TableHead>{t('recon.kind')}</TableHead>
+                  <TableHead>{t('recon.policy')}</TableHead>
+                  <TableHead>{t('recon.method')}</TableHead>
+                  <TableHead>{t('recon.by')}</TableHead>
+                  <TableHead className="text-right">{t('recon.total')}</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {data.returns.length === 0 ? (
+                  <TableRow>
+                    <TableCell colSpan={7} className="py-4 text-center text-muted-foreground">
+                      {t('recon.none')}
+                    </TableCell>
+                  </TableRow>
+                ) : (
+                  data.returns.map((r) => {
+                    const method = r.refund > 0 ? r.refundMethod : r.collectedMethod;
+                    return (
+                      <TableRow key={r.returnNo}>
+                        <TableCell className="font-mono">{r.returnNo}</TableCell>
+                        <TableCell className="font-mono">{r.saleReceiptNo}</TableCell>
+                        <TableCell>{t(`recon.returnKinds.${r.kind}`)}</TableCell>
+                        <TableCell>
+                          {r.withinPolicy === false ? (
+                            <span
+                              className="font-medium text-destructive"
+                              title={r.overrideReason ?? undefined}
+                            >
+                              {t('recon.override')}
+                            </span>
+                          ) : r.withinPolicy ? (
+                            t('recon.withinPolicy')
+                          ) : (
+                            '—'
+                          )}
+                        </TableCell>
+                        <TableCell>{method ? methodLabel(method) : '—'}</TableCell>
+                        <TableCell>{r.seller ?? '—'}</TableCell>
+                        {/* Signed: a refund leaves the till, a top-up on a
+                            dearer exchange comes into it. */}
+                        <TableCell className="text-right tabular-nums">
+                          {r.refund > 0 ? `− ${money(r.refund)}` : money(r.collected)}
+                        </TableCell>
+                      </TableRow>
+                    );
+                  })
+                )}
+              </TableBody>
+            </Table>
+          </div>
+        </CardContent>
+      </Card>
+
       <Card>
         <CardHeader>
           <CardTitle className="text-base">{t('recon.cancellations')}</CardTitle>

--- a/src/lib/report-types.ts
+++ b/src/lib/report-types.ts
@@ -45,6 +45,15 @@ export const REPORT_KEYS = [
   'production',
   'orders-turnaround',
   'cancellations',
+  /**
+   * Returns and exchanges, with the out-of-policy ones flagged (A-FR-8.12).
+   *
+   * Lists every return rather than only the overrides. "How often is the rule
+   * being set aside" is a rate, and a rate needs a denominator -- three
+   * overrides out of four returns is a different conversation from three out of
+   * ninety.
+   */
+  'returns-overrides',
   'audit'
 ] as const;
 

--- a/src/lib/validation/return-schema.ts
+++ b/src/lib/validation/return-schema.ts
@@ -30,11 +30,24 @@ const quantity = z.coerce
   .positive({ message: 'positive' })
   .max(9999);
 
-/** A garment coming back. Identified by the sale line it was bought on. */
-export const returnedLineSchema = z.object({
-  saleItemId: z.uuid({ message: 'required' }),
-  quantity
-});
+/**
+ * A garment coming back, identified by where the parent got it: the sale line
+ * it was bought on, or the outgoing line of an earlier exchange (A-FR-8.13).
+ *
+ * Exactly one, never both. Neither means there is nothing to price the refund
+ * against; both would mean two different histories for one garment. The
+ * database enforces the same rule independently.
+ */
+export const returnedLineSchema = z
+  .object({
+    saleItemId: z.uuid().nullable().default(null),
+    sourceReturnItemId: z.uuid().nullable().default(null),
+    quantity
+  })
+  .refine(
+    (line) => (line.saleItemId === null) !== (line.sourceReturnItemId === null),
+    { message: 'required', path: ['saleItemId'] }
+  );
 
 /** A garment going out in exchange. A fresh catalogue pick, not an old line. */
 export const outgoingLineSchema = z.object({

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -895,8 +895,13 @@ export type Database = {
           id: string;
           return_id: string;
           direction: ReturnDirection;
-          /** Set on the way in, null on the way out. */
+          /**
+           * Where the garment came from. Exactly one is set on an incoming
+           * line, both null on an outgoing one (A-FR-8.13).
+           */
           sale_item_id: string | null;
+          /** The outgoing line it was received on in an earlier exchange. */
+          source_return_item_id: string | null;
           product_id: string;
           description: string;
           size: string | null;
@@ -909,6 +914,7 @@ export type Database = {
           return_id: string;
           direction: ReturnDirection;
           sale_item_id?: string | null;
+          source_return_item_id?: string | null;
           product_id: string;
           description: string;
           size?: string | null;
@@ -922,6 +928,12 @@ export type Database = {
             foreignKeyName: 'return_items_return_id_fkey';
             columns: ['return_id'];
             referencedRelation: 'returns';
+            referencedColumns: ['id'];
+          },
+          {
+            foreignKeyName: 'return_items_source_return_item_id_fkey';
+            columns: ['source_return_item_id'];
+            referencedRelation: 'return_items';
             referencedColumns: ['id'];
           },
           {
@@ -1014,6 +1026,7 @@ export type Database = {
           p_kind: ReturnKind;
           p_reason: string;
           p_condition: GarmentCondition;
+          /** [{sale_item_id | source_return_item_id, quantity}] */
           p_in_items: Json;
           p_out_items: Json;
           /**

--- a/supabase/migrations/20260101003500_exchange_chain.sql
+++ b/supabase/migrations/20260101003500_exchange_chain.sql
@@ -1,0 +1,117 @@
+-- A garment received in an exchange can be given back too (A-FR-8.13).
+--
+-- Until now an incoming line had to name a row of sale_items, so only something
+-- originally BOUGHT could come back. A replacement garment is a return_items
+-- row with direction 'out' -- it has no sale line, so it could never be
+-- returned. A parent who swapped M for L and found L also wrong was stuck, on
+-- day one, inside every window.
+--
+-- That was stricter than the requirement intends. A-FR-8.13's worry is that
+-- "a garment can be exchanged indefinitely", and the answer to that is the
+-- clock, not a prohibition: the elapsed time keeps running from the ORIGINAL
+-- sale however many times the garment is swapped. The second exchange is
+-- allowed; it is simply judged against the same deadline as the first.
+
+-- --------------------------------------------------------------- the link
+--
+-- An incoming line now names either the sale line it was bought on, or the
+-- outgoing line it was received on. Never both, and never neither.
+alter table public.return_items
+  add column source_return_item_id uuid references public.return_items (id) on delete restrict;
+
+create index return_items_source_idx
+  on public.return_items (source_return_item_id)
+  where source_return_item_id is not null;
+
+-- Replaces the constraint from 20260101002800, which required sale_item_id on
+-- every incoming line.
+alter table public.return_items
+  drop constraint if exists return_items_in_needs_sale_line;
+
+alter table public.return_items
+  add constraint return_items_in_needs_a_source check (
+    (direction = 'in' and (sale_item_id is not null) <> (source_return_item_id is not null))
+    or (direction = 'out' and sale_item_id is null and source_return_item_id is null)
+  );
+
+-- ------------------------------------------------- how much is still returnable
+--
+-- Rewritten to answer the same question for both kinds of source: how many of
+-- this garment did the parent receive, and how many have they already given
+-- back. Without it a return refunds money for goods that were never handed over
+-- -- by over-returning a line, or by returning the same one twice.
+--
+-- security definer so the check still runs for a caller who may insert a return
+-- line but cannot read every sale line.
+create or replace function public.enforce_returnable_quantity()
+returns trigger
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $fn$
+declare
+  v_received  integer;
+  v_returned  integer;
+  v_owner     uuid;      -- the sale this line's history belongs to
+  v_this_sale uuid;
+begin
+  if new.direction <> 'in' then
+    return new;
+  end if;
+
+  select r.sale_id into v_this_sale
+  from public.returns r
+  where r.id = new.return_id;
+
+  if new.sale_item_id is not null then
+    -- Bought outright: the sale line says how many were received.
+    select si.quantity, si.sale_id into v_received, v_owner
+    from public.sale_items si
+    where si.id = new.sale_item_id;
+
+    if v_received is null then
+      raise exception 'That sale line does not exist';
+    end if;
+
+    select coalesce(sum(ri.quantity), 0) into v_returned
+    from public.return_items ri
+    where ri.sale_item_id = new.sale_item_id
+      and ri.direction = 'in'
+      and ri.id is distinct from new.id;
+  else
+    -- Received in an exchange: the outgoing line says how many were handed over,
+    -- and the return it belongs to says which sale the whole chain descends
+    -- from. Following that back is what keeps the clock on the original sale
+    -- however long the chain gets.
+    select src.quantity, r.sale_id into v_received, v_owner
+    from public.return_items src
+    join public.returns r on r.id = src.return_id
+    where src.id = new.source_return_item_id
+      and src.direction = 'out';
+
+    if v_received is null then
+      raise exception 'That line was never handed over in an exchange';
+    end if;
+
+    select coalesce(sum(ri.quantity), 0) into v_returned
+    from public.return_items ri
+    where ri.source_return_item_id = new.source_return_item_id
+      and ri.direction = 'in'
+      and ri.id is distinct from new.id;
+  end if;
+
+  -- The line has to belong to the sale this return is against, or a return
+  -- could quietly refund against someone else's purchase.
+  if v_owner is distinct from v_this_sale then
+    raise exception 'That line belongs to a different sale';
+  end if;
+
+  if v_returned + new.quantity > v_received then
+    raise exception
+      'Only % of that item remain returnable (% received, % already returned).',
+      v_received - v_returned, v_received, v_returned;
+  end if;
+
+  return new;
+end;
+$fn$;

--- a/supabase/migrations/20260101003600_record_return_chain.sql
+++ b/supabase/migrations/20260101003600_record_return_chain.sql
@@ -1,0 +1,340 @@
+-- record_return() accepts a garment received in an earlier exchange (A-FR-8.13).
+--
+-- Replaces the body from 20260101003200. The signature is unchanged, so this is
+-- a plain `create or replace` -- no drop, no PostgREST ambiguity.
+--
+-- p_in_items entries now carry EITHER "sale_item_id" (bought outright) or
+-- "source_return_item_id" (received in an exchange). The quantity check that
+-- decides how many remain returnable lives in the trigger on return_items and
+-- handles both.
+--
+-- The clock does not move. `returns.sale_id` is still the ORIGINAL sale, and the
+-- verdict is still computed from its sold_at, however many times the garment has
+-- been swapped -- which is precisely what A-FR-8.13 asks for.
+
+create or replace function public.record_return(
+  p_sale_id          uuid,
+  p_kind             public.return_kind,
+  p_reason           text,
+  p_condition        public.garment_condition,
+  p_in_items         jsonb,
+  p_out_items        jsonb,
+  p_refund_method    public.payment_method,
+  p_collected_method public.payment_method,
+  p_received_by      uuid,
+  p_notes            text,
+  p_signature_url    text,
+  -- Required only when the verdict says out of policy. The form asks for it
+  -- once the warning appears; the check below is what makes it mandatory.
+  p_override_reason  text default null
+)
+returns table (
+  id uuid,
+  return_no text,
+  refund_amount numeric,
+  collected_amount numeric,
+  within_policy boolean,
+  elapsed_days integer
+)
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $fn$
+declare
+  v_actor     uuid := auth.uid();
+  v_return    uuid;
+  v_reason    text := nullif(btrim(coalesce(p_reason, '')), '');
+  v_override  text := nullif(btrim(coalesce(p_override_reason, '')), '');
+  v_sold_at   timestamptz;
+  v_elapsed   integer;
+  v_window    integer;
+  v_within    boolean;
+  v_value_in  numeric(12, 2) := 0;
+  v_value_out numeric(12, 2) := 0;
+  v_diff      numeric(12, 2);
+  v_refund    numeric(12, 2) := 0;
+  v_collect   numeric(12, 2) := 0;
+  v_line      record;
+begin
+  if v_actor is null then
+    raise exception 'Not signed in';
+  end if;
+
+  -- Administration is read-only (A-FR-2.2).
+  if not public.can_operate() then
+    raise exception 'Your role cannot record a return';
+  end if;
+
+  if p_sale_id is null then
+    raise exception 'A return must reference the original sale';
+  end if;
+
+  -- Aliased: the OUT parameters are variables in scope for the whole body, so
+  -- an unqualified `id` here would be ambiguous between column and variable.
+  select s.sold_at into v_sold_at from public.sales s where s.id = p_sale_id;
+  if v_sold_at is null then
+    raise exception 'That sale does not exist';
+  end if;
+
+  if v_reason is null or length(v_reason) < 3 then
+    raise exception 'A return needs a reason';
+  end if;
+
+  -- --------------------------------------------------------- the verdict
+  --
+  -- Computed from the ORIGINAL sale date (A-FR-8.13). An exchange does not
+  -- restart the clock, or a garment could be swapped indefinitely.
+  select v.elapsed_days, v.window_days, v.within_policy
+    into v_elapsed, v_window, v_within
+  from public.return_policy_verdict(v_sold_at, p_kind, p_condition) v;
+
+  -- The seller was warned on screen and asked to explain. This is the same rule
+  -- applied where it cannot be skipped -- a direct PostgREST call never sees
+  -- the form. It refuses the MISSING EXPLANATION, never the return itself.
+  if not v_within and v_override is null then
+    raise exception
+      'This is outside the % policy (% days since the sale, window %). Give a reason to proceed.',
+      p_kind, v_elapsed, coalesce(v_window::text, 'not permitted');
+  end if;
+
+  if p_in_items is null
+     or jsonb_typeof(p_in_items) <> 'array'
+     or jsonb_array_length(p_in_items) = 0 then
+    raise exception 'Add at least one garment being returned';
+  end if;
+
+  if p_kind = 'exchange'
+     and (p_out_items is null
+          or jsonb_typeof(p_out_items) <> 'array'
+          or jsonb_array_length(p_out_items) = 0) then
+    raise exception 'An exchange needs at least one garment going out';
+  end if;
+
+  if p_kind = 'return'
+     and p_out_items is not null
+     and jsonb_typeof(p_out_items) = 'array'
+     and jsonb_array_length(p_out_items) > 0 then
+    raise exception 'A return takes nothing out. Record an exchange instead.';
+  end if;
+
+  -- The verdict is stored, not recomputed on read: the windows are editable, so
+  -- a return judged in-policy today would silently become an override the
+  -- moment someone shortens a window.
+  insert into public.returns (
+    kind, sale_id, reason, condition,
+    refund_method, collected_method,
+    notes, signature_url,
+    seller_id, recorded_by, received_by,
+    elapsed_days, policy_window_days, within_policy, override_reason
+  )
+  values (
+    p_kind, p_sale_id, v_reason, p_condition,
+    p_refund_method, p_collected_method,
+    nullif(btrim(coalesce(p_notes, '')), ''), p_signature_url,
+    v_actor, v_actor, coalesce(p_received_by, v_actor),
+    v_elapsed, v_window, v_within, case when not v_within then v_override end
+  )
+  returning returns.id into v_return;
+
+  -- ------------------------------------------------------------- coming back
+  for v_line in
+    select (item ->> 'sale_item_id')::uuid           as sale_item_id,
+           (item ->> 'source_return_item_id')::uuid  as source_return_item_id,
+           (item ->> 'quantity')::integer            as quantity
+    from jsonb_array_elements(p_in_items) as item
+  loop
+    -- Exactly one source. Neither means there is nothing to price the refund
+    -- against; both would mean two different histories for one garment.
+    if (v_line.sale_item_id is null) = (v_line.source_return_item_id is null) then
+      raise exception
+        'Every returned line must name either a line of the original sale or a garment handed over in an exchange';
+    end if;
+    if v_line.quantity is null or v_line.quantity <= 0 then
+      raise exception 'Returned quantity must be greater than zero';
+    end if;
+
+    if v_line.sale_item_id is not null then
+      -- Priced from the SALE, not the catalogue: the parent gets back what they
+      -- paid, which is not what the garment costs today.
+      insert into public.return_items (
+        return_id, direction, sale_item_id, source_return_item_id, product_id,
+        description, size, unit_price, quantity, line_total
+      )
+      select v_return, 'in', si.id, null, si.product_id,
+             si.description, si.size, si.unit_price, v_line.quantity,
+             si.unit_price * v_line.quantity
+      from public.sale_items si
+      where si.id = v_line.sale_item_id;
+
+      if not found then
+        raise exception 'That sale line does not exist';
+      end if;
+
+      insert into public.stock_movements (product_id, kind, quantity, return_id, note, created_by)
+      select si.product_id, 'return', v_line.quantity, v_return, v_reason, v_actor
+      from public.sale_items si
+      where si.id = v_line.sale_item_id
+        and si.product_id is not null;
+    else
+      -- Priced from the OUTGOING line it was received on -- what the garment was
+      -- valued at when it was handed over, which is what the exchange
+      -- difference was settled against.
+      insert into public.return_items (
+        return_id, direction, sale_item_id, source_return_item_id, product_id,
+        description, size, unit_price, quantity, line_total
+      )
+      select v_return, 'in', null, src.id, src.product_id,
+             src.description, src.size, src.unit_price, v_line.quantity,
+             src.unit_price * v_line.quantity
+      from public.return_items src
+      where src.id = v_line.source_return_item_id
+        and src.direction = 'out';
+
+      if not found then
+        raise exception 'That line was never handed over in an exchange';
+      end if;
+
+      insert into public.stock_movements (product_id, kind, quantity, return_id, note, created_by)
+      select src.product_id, 'return', v_line.quantity, v_return, v_reason, v_actor
+      from public.return_items src
+      where src.id = v_line.source_return_item_id;
+    end if;
+  end loop;
+
+  -- ---------------------------------------------------------- going back out
+  if p_kind = 'exchange' then
+    for v_line in
+      select (item ->> 'product_id')::uuid as product_id,
+             (item ->> 'quantity')::integer as quantity
+      from jsonb_array_elements(p_out_items) as item
+    loop
+      if v_line.product_id is null then
+        raise exception 'Every outgoing line needs a product';
+      end if;
+      if v_line.quantity is null or v_line.quantity <= 0 then
+        raise exception 'Outgoing quantity must be greater than zero';
+      end if;
+
+      insert into public.return_items (
+        return_id, direction, sale_item_id, product_id,
+        description, size, unit_price, quantity, line_total
+      )
+      select v_return, 'out', null, p.id,
+             coalesce(p.name_en, p.name_fr), p.size, p.unit_price, v_line.quantity,
+             p.unit_price * v_line.quantity
+      from public.products p
+      where p.id = v_line.product_id
+        and p.is_active;
+
+      if not found then
+        raise exception 'That product is not available';
+      end if;
+
+      -- Leaves stock, but as an exchange rather than a sale: no money was taken
+      -- for this garment, only for the difference.
+      insert into public.stock_movements (product_id, kind, quantity, return_id, note, created_by)
+      values (v_line.product_id, 'exchange', -v_line.quantity, v_return, v_reason, v_actor);
+    end loop;
+  end if;
+
+  -- ------------------------------------------------------------- the balance
+  select coalesce(sum(ri.line_total) filter (where ri.direction = 'in'), 0),
+         coalesce(sum(ri.line_total) filter (where ri.direction = 'out'), 0)
+    into v_value_in, v_value_out
+  from public.return_items ri
+  where ri.return_id = v_return;
+
+  v_diff := v_value_out - v_value_in;
+  if v_diff > 0 then
+    v_collect := v_diff;
+  elsif v_diff < 0 then
+    v_refund := -v_diff;
+  end if;
+
+  if v_refund > 0 and p_refund_method is null then
+    raise exception 'Choose how the refund is being paid';
+  end if;
+  if v_collect > 0 and p_collected_method is null then
+    raise exception 'Choose how the difference is being collected';
+  end if;
+
+  update public.returns
+     set refund_amount    = v_refund,
+         collected_amount = v_collect,
+         refund_method    = case when v_refund  > 0 then p_refund_method    end,
+         collected_method = case when v_collect > 0 then p_collected_method end
+   where returns.id = v_return;
+
+  insert into public.audit_log (actor_id, action, entity, target_table, target_id, meta)
+  values (
+    v_actor,
+    case when p_kind = 'exchange' then 'exchange_recorded' else 'return_recorded' end,
+    v_return::text,
+    'returns',
+    v_return::text,
+    jsonb_build_object(
+      'sale_id', p_sale_id,
+      'reason', v_reason,
+      'condition', p_condition,
+      'elapsed_days', v_elapsed,
+      'policy_window_days', v_window,
+      'within_policy', v_within,
+      'value_in', v_value_in,
+      'value_out', v_value_out,
+      'refund_amount', v_refund,
+      'refund_method', case when v_refund > 0 then p_refund_method end,
+      'collected_amount', v_collect,
+      'collected_method', case when v_collect > 0 then p_collected_method end
+    )
+  );
+
+  -- A second row, only for an override, with its own action name.
+  --
+  -- The transaction row above already carries within_policy, but "how often is
+  -- the rule being set aside, and by whom" (A-FR-8.12) is a question about
+  -- DECISIONS, not transactions. Giving it its own action means the audit
+  -- screen can filter to exactly that, the way sale_below_stock_override
+  -- already does for the equivalent decision on a sale.
+  if not v_within then
+    insert into public.audit_log (
+      actor_id, actor_name, action, entity, target_table, target_id, meta
+    )
+    select
+      v_actor,
+      p.full_name,
+      'return_policy_override',
+      r.return_no,
+      'returns',
+      v_return::text,
+      jsonb_build_object(
+        'return_no', r.return_no,
+        'kind', p_kind,
+        'condition', p_condition,
+        'elapsed_days', v_elapsed,
+        'policy_window_days', v_window,
+        'override_reason', v_override,
+        'refund_amount', v_refund,
+        'collected_amount', v_collect
+      )
+    from public.returns r
+    left join public.profiles p on p.id = v_actor
+    where r.id = v_return;
+  end if;
+
+  return query
+  select r.id, r.return_no, r.refund_amount, r.collected_amount,
+         r.within_policy, r.elapsed_days
+  from public.returns r
+  where r.id = v_return;
+end;
+$fn$;
+
+revoke all on function public.record_return(
+  uuid, public.return_kind, text, public.garment_condition, jsonb, jsonb,
+  public.payment_method, public.payment_method, uuid, text, text, text
+) from public;
+
+grant execute on function public.record_return(
+  uuid, public.return_kind, text, public.garment_condition, jsonb, jsonb,
+  public.payment_method, public.payment_method, uuid, text, text, text
+) to authenticated;

--- a/supabase/migrations/rollback/20260101003500_exchange_chain_down.sql
+++ b/supabase/migrations/rollback/20260101003500_exchange_chain_down.sql
@@ -1,0 +1,27 @@
+-- Down for 20260101003500_exchange_chain.sql.
+--
+-- Run 20260101003600_record_return_chain_down.sql FIRST.
+--
+-- Rows created by a chained exchange cannot be represented once the column is
+-- gone, so this refuses rather than silently orphaning them.
+
+do $$
+begin
+  if exists (select 1 from public.return_items where source_return_item_id is not null) then
+    raise exception
+      'Returns exist against garments received in an exchange. Reverse them before rolling this back.';
+  end if;
+end
+$$;
+
+alter table public.return_items
+  drop constraint if exists return_items_in_needs_a_source;
+
+alter table public.return_items
+  add constraint return_items_in_needs_sale_line check (
+    (direction = 'in' and sale_item_id is not null)
+    or (direction = 'out' and sale_item_id is null)
+  );
+
+drop index if exists public.return_items_source_idx;
+alter table public.return_items drop column if exists source_return_item_id;

--- a/supabase/migrations/rollback/20260101003600_record_return_chain_down.sql
+++ b/supabase/migrations/rollback/20260101003600_record_return_chain_down.sql
@@ -1,0 +1,10 @@
+-- Down for 20260101003600_record_return_chain.sql.
+--
+-- Re-apply 20260101003200_record_return_policy.sql by hand to restore the
+-- previous body. The signature is identical, so `create or replace` from that
+-- file is the whole rollback -- it is not duplicated here, because two copies
+-- of a 260-line function drift apart and the migration that owns it is the
+-- honest source.
+--
+-- Run 20260101003500_exchange_chain_down.sql AFTER this: the older body does
+-- not reference source_return_item_id, so the column can then be dropped.


### PR DESCRIPTION
Closes #40.

## A-FR-8.14 was already met by #39

The RTN receipt already prints the declared condition, the elapsed days and
the verdict. Checked, not rebuilt.

## A-FR-8.13 was half met

Elapsed time already ran from the original sale. But a garment **received in
an exchange could never be given back** — every incoming line had to name a
`sale_items` row, and a replacement has none. A parent who swapped M for L and
found L wrong was stuck on day one, inside every window.

That's stricter than the requirement intends. Its stated worry is that *"a
garment can be exchanged indefinitely"* — and the answer to that is the clock,
not a prohibition. An incoming line now names **either** the sale line it was
bought on **or** the outgoing line it was received on, and `returns.sale_id`
still points at the original sale, so the deadline never moves however long
the chain gets.

## A-FR-8.12 was missing, and building it surfaced a cash bug

`refundsByMethod` was built only from cancelled **order lines**. A cash refund
for a **return** never reduced `netCashInBox` — so the drawer couldn't balance
on any day a garment came back. Exchange top-ups were missing in the other
direction. Both now feed the reconciliation, and the daily report gains a
**Returns & exchanges** card with an override count.

The dedicated report is a seventh kind in the existing suite,
`returns-overrides`, inheriting the date filters, stamped Excel/PDF export and
print view rather than duplicating them.

It lists **every** return with overrides sorted to the top, because *"how often
is the rule being set aside"* is a rate — three out of four is a different
conversation from three out of ninety. `within_policy` null is counted as
neither: those rows predate the policy engine, so no rule was set aside
because there was no rule.

## Tested

Full chain verified in the app and in the data:
