### PR TITLE
PR/feat(reports): returns/exchanges report, out-of-policy recon flag, document QR codes

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -819,26 +819,12 @@
       "item": "Item",
       "refundMethod": "Refund method",
       "when": "When",
-      "outOfPolicy": "Out-of-policy returns & exchanges",
-      "return": "Return",
-      "saleRef": "Sale ref.",
-      "kind": "Type",
-      "condition": "Condition",
-      "elapsedDays": "Days elapsed",
       "none": "None",
       "methods": {
         "cash": "Cash",
         "mobile_money": "MoMo",
         "orange_money": "Orange Money",
         "bank_transfer": "Bank transfer"
-      },
-      "kinds": {
-        "return": "Return",
-        "exchange": "Exchange"
-      },
-      "conditions": {
-        "unworn": "Unworn",
-        "worn": "Worn"
       }
     },
     "suite": {
@@ -867,22 +853,12 @@
       "ordersSummary": "{placed} placed, {fulfilled} fulfilled",
       "avgTurnaround": "Avg (days)",
       "wholeSale": "Whole sale cancelled",
-      "override": "Override",
-      "withinPolicy": "Within policy",
-      "returnKind": {
-        "return": "Return",
-        "exchange": "Exchange"
-      },
-      "condition": {
-        "unworn": "Unworn",
-        "worn": "Worn"
-      },
       "reports": {
         "sales-by-period": "Sales by period",
         "sales-by-garment": "Sales by garment & size",
         "production": "Production by period",
         "orders-turnaround": "Orders placed & fulfilled",
-        "returns-exchanges": "Returns & exchanges",
+        "returns-overrides": "Returns & exchanges",
         "cancellations": "Cancellations",
         "audit": "Audit log"
       },
@@ -923,16 +899,7 @@
         "actor": "User",
         "action": "Action",
         "target": "Target",
-        "details": "Details",
-        "returnNo": "Return no.",
-        "saleRef": "Sale ref.",
-        "kind": "Type",
-        "condition": "Condition",
-        "elapsedDays": "Days elapsed",
-        "verdict": "Policy",
-        "refund": "Refund",
-        "collected": "Collected",
-        "collectedMethod": "Collected method"
+        "details": "Details"
       }
     }
   },

--- a/messages/en.json
+++ b/messages/en.json
@@ -805,12 +805,26 @@
       "item": "Item",
       "refundMethod": "Refund method",
       "when": "When",
+      "outOfPolicy": "Out-of-policy returns & exchanges",
+      "return": "Return",
+      "saleRef": "Sale ref.",
+      "kind": "Type",
+      "condition": "Condition",
+      "elapsedDays": "Days elapsed",
       "none": "None",
       "methods": {
         "cash": "Cash",
         "mobile_money": "MoMo",
         "orange_money": "Orange Money",
         "bank_transfer": "Bank transfer"
+      },
+      "kinds": {
+        "return": "Return",
+        "exchange": "Exchange"
+      },
+      "conditions": {
+        "unworn": "Unworn",
+        "worn": "Worn"
       }
     },
     "suite": {
@@ -828,11 +842,22 @@
       "ordersSummary": "{placed} placed, {fulfilled} fulfilled",
       "avgTurnaround": "Avg (days)",
       "wholeSale": "Whole sale cancelled",
+      "override": "Override",
+      "withinPolicy": "Within policy",
+      "returnKind": {
+        "return": "Return",
+        "exchange": "Exchange"
+      },
+      "condition": {
+        "unworn": "Unworn",
+        "worn": "Worn"
+      },
       "reports": {
         "sales-by-period": "Sales by period",
         "sales-by-garment": "Sales by garment & size",
         "production": "Production by period",
         "orders-turnaround": "Orders placed & fulfilled",
+        "returns-exchanges": "Returns & exchanges",
         "cancellations": "Cancellations",
         "audit": "Audit log"
       },
@@ -861,7 +886,16 @@
         "actor": "User",
         "action": "Action",
         "target": "Target",
-        "details": "Details"
+        "details": "Details",
+        "returnNo": "Return no.",
+        "saleRef": "Sale ref.",
+        "kind": "Type",
+        "condition": "Condition",
+        "elapsedDays": "Days elapsed",
+        "verdict": "Policy",
+        "refund": "Refund",
+        "collected": "Collected",
+        "collectedMethod": "Collected method"
       }
     }
   },

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -805,12 +805,26 @@
       "item": "Article",
       "refundMethod": "Mode de remboursement",
       "when": "Quand",
+      "outOfPolicy": "Retours et \u00e9changes hors d\u00e9lais",
+      "return": "Retour",
+      "saleRef": "R\u00e9f. vente",
+      "kind": "Type",
+      "condition": "\u00c9tat",
+      "elapsedDays": "Jours \u00e9coul\u00e9s",
       "none": "Aucun",
       "methods": {
         "cash": "Esp\u00e8ces",
         "mobile_money": "MoMo",
         "orange_money": "Orange Money",
         "bank_transfer": "Virement bancaire"
+      },
+      "kinds": {
+        "return": "Retour",
+        "exchange": "\u00c9change"
+      },
+      "conditions": {
+        "unworn": "Non port\u00e9",
+        "worn": "Port\u00e9"
       }
     },
     "suite": {
@@ -828,11 +842,22 @@
       "ordersSummary": "{placed} passées, {fulfilled} livrées",
       "avgTurnaround": "Moy. (jours)",
       "wholeSale": "Vente entière annulée",
+      "override": "Dérogation",
+      "withinPolicy": "Dans les délais",
+      "returnKind": {
+        "return": "Retour",
+        "exchange": "Échange"
+      },
+      "condition": {
+        "unworn": "Non porté",
+        "worn": "Porté"
+      },
       "reports": {
         "sales-by-period": "Ventes par période",
         "sales-by-garment": "Ventes par article et taille",
         "production": "Production par période",
         "orders-turnaround": "Commandes passées et livrées",
+        "returns-exchanges": "Retours et échanges",
         "cancellations": "Annulations",
         "audit": "Journal d'audit"
       },
@@ -861,7 +886,16 @@
         "actor": "Utilisateur",
         "action": "Action",
         "target": "Cible",
-        "details": "Détails"
+        "details": "Détails",
+        "returnNo": "N° retour",
+        "saleRef": "Réf. vente",
+        "kind": "Type",
+        "condition": "État",
+        "elapsedDays": "Jours écoulés",
+        "verdict": "Politique",
+        "refund": "Remboursé",
+        "collected": "Encaissé",
+        "collectedMethod": "Mode d'encaissement"
       }
     }
   },

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -819,26 +819,12 @@
       "item": "Article",
       "refundMethod": "Mode de remboursement",
       "when": "Quand",
-      "outOfPolicy": "Retours et \u00e9changes hors d\u00e9lais",
-      "return": "Retour",
-      "saleRef": "R\u00e9f. vente",
-      "kind": "Type",
-      "condition": "\u00c9tat",
-      "elapsedDays": "Jours \u00e9coul\u00e9s",
       "none": "Aucun",
       "methods": {
         "cash": "Esp\u00e8ces",
         "mobile_money": "MoMo",
         "orange_money": "Orange Money",
         "bank_transfer": "Virement bancaire"
-      },
-      "kinds": {
-        "return": "Retour",
-        "exchange": "\u00c9change"
-      },
-      "conditions": {
-        "unworn": "Non port\u00e9",
-        "worn": "Port\u00e9"
       }
     },
     "suite": {
@@ -867,22 +853,12 @@
       "ordersSummary": "{placed} passées, {fulfilled} livrées",
       "avgTurnaround": "Moy. (jours)",
       "wholeSale": "Vente entière annulée",
-      "override": "Dérogation",
-      "withinPolicy": "Dans les délais",
-      "returnKind": {
-        "return": "Retour",
-        "exchange": "Échange"
-      },
-      "condition": {
-        "unworn": "Non porté",
-        "worn": "Porté"
-      },
       "reports": {
         "sales-by-period": "Ventes par période",
         "sales-by-garment": "Ventes par article et taille",
         "production": "Production par période",
         "orders-turnaround": "Commandes passées et livrées",
-        "returns-exchanges": "Retours et échanges",
+        "returns-overrides": "Retours et échanges",
         "cancellations": "Annulations",
         "audit": "Journal d'audit"
       },
@@ -923,16 +899,7 @@
         "actor": "Utilisateur",
         "action": "Action",
         "target": "Cible",
-        "details": "Détails",
-        "returnNo": "N° retour",
-        "saleRef": "Réf. vente",
-        "kind": "Type",
-        "condition": "État",
-        "elapsedDays": "Jours écoulés",
-        "verdict": "Politique",
-        "refund": "Remboursé",
-        "collected": "Encaissé",
-        "collectedMethod": "Mode d'encaissement"
+        "details": "Détails"
       }
     }
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "next": "16.3.3",
         "next-intl": "^4.13.7",
         "next-themes": "^0.4.6",
+        "qrcode": "^1.5.4",
         "radix-ui": "^1.6.7",
         "react": "19.2.8",
         "react-dom": "19.2.8",
@@ -32,6 +33,7 @@
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
         "@types/node": "^20",
+        "@types/qrcode": "^1.5.6",
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "@types/react-signature-canvas": "^1.0.7",
@@ -5884,6 +5886,16 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@types/qrcode": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/@types/qrcode/-/qrcode-1.5.6.tgz",
+      "integrity": "sha512-te7NQcV2BOvdj2b1hCAHzAoMNuj65kNBMz0KBaxM6c3VGBOhU0dURQKOtH8CFNI/dsKkwlv32p26qYQTWoB5bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/react": {
       "version": "19.2.18",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.18.tgz",
@@ -6830,7 +6842,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6840,7 +6851,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -7334,6 +7344,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001810",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001810.tgz",
@@ -7434,6 +7453,37 @@
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
     },
+    "node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
+    "node_modules/cliui/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -7454,7 +7504,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -7467,7 +7516,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/commander": {
@@ -7762,6 +7810,15 @@
         }
       }
     },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/dedent": {
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.2.tgz",
@@ -7907,6 +7964,12 @@
       "engines": {
         "node": ">=0.3.1"
       }
+    },
+    "node_modules/dijkstrajs": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
+      "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
+      "license": "MIT"
     },
     "node_modules/doctrine": {
       "version": "2.1.0",
@@ -9188,6 +9251,15 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
     "node_modules/get-east-asian-width": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
@@ -9953,6 +10025,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-generator-function": {
@@ -11806,7 +11887,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -12044,6 +12124,15 @@
         "node": ">=4"
       }
     },
+    "node_modules/pngjs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/po-parser": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/po-parser/-/po-parser-2.2.0.tgz",
@@ -12214,6 +12303,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qrcode": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
+      "integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "dijkstrajs": "^1.0.1",
+        "pngjs": "^5.0.0",
+        "yargs": "^15.3.1"
+      },
+      "bin": {
+        "qrcode": "bin/qrcode"
+      },
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/qs": {
@@ -12564,6 +12670,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -12585,6 +12700,12 @@
       "engines": {
         "node": ">=9.3.0 || >=8.10.0 <9.0.0"
       }
+    },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "license": "ISC"
     },
     "node_modules/resolve": {
       "version": "2.0.0-next.7",
@@ -12922,6 +13043,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "license": "ISC"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
@@ -13600,7 +13727,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -14528,6 +14654,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/which-module": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+      "license": "ISC"
+    },
     "node_modules/which-typed-array": {
       "version": "1.1.22",
       "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.22.tgz",
@@ -14558,6 +14690,40 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wrappy": {
@@ -14609,11 +14775,124 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "license": "ISC"
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/yargs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/yargs/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yargs/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "next": "16.3.3",
     "next-intl": "^4.13.7",
     "next-themes": "^0.4.6",
+    "qrcode": "^1.5.4",
     "radix-ui": "^1.6.7",
     "react": "19.2.8",
     "react-dom": "19.2.8",
@@ -43,6 +44,7 @@
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
+    "@types/qrcode": "^1.5.6",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "@types/react-signature-canvas": "^1.0.7",

--- a/src/actions/reports.ts
+++ b/src/actions/reports.ts
@@ -72,6 +72,20 @@ export type DailyReconciliation = {
     reason: string | null;
     at: string | null;
   }[];
+  /**
+   * Returns and exchanges done outside the policy window (A-FR-8.12). Flagged
+   * here so the day's overrides are visible in the report the administration
+   * reads every evening, not only in the dedicated returns report.
+   */
+  outOfPolicy: {
+    returnNo: string;
+    saleRef: string;
+    kind: 'return' | 'exchange';
+    condition: 'unworn' | 'worn';
+    elapsedDays: number | null;
+    reason: string | null;
+    at: string | null;
+  }[];
 };
 
 const MOBILE_METHODS: PaymentMethod[] = ['mobile_money', 'orange_money'];
@@ -105,7 +119,7 @@ export async function getDailyReconciliation(
   const fromIso = new Date(`${from}T00:00:00`).toISOString();
   const toIso = new Date(`${to}T23:59:59.999`).toISOString();
 
-  const [salesRes, cancelRes, orderRes] = await Promise.all([
+  const [salesRes, cancelRes, orderRes, outOfPolicyRes] = await Promise.all([
     admin
       .from('sales')
       .select(
@@ -133,12 +147,27 @@ export async function getDailyReconciliation(
       .from('orders')
       .select('id, ordered_at, items:order_items ( line_total, status )')
       .gte('ordered_at', fromIso)
-      .lte('ordered_at', toIso)
+      .lte('ordered_at', toIso),
+    // Out-of-policy returns/exchanges of the day (A-FR-8.12). `within_policy`
+    // is the verdict stamped at the time, so a later change to the windows does
+    // not retroactively reclassify what happened.
+    admin
+      .from('returns')
+      .select(
+        `return_no, kind, condition, elapsed_days, returned_at,
+         override_reason, reason,
+         sale:sales!returns_sale_id_fkey ( receipt_no )`
+      )
+      .is('within_policy', false)
+      .gte('returned_at', fromIso)
+      .lte('returned_at', toIso)
+      .order('returned_at', { ascending: true })
   ]);
 
   const sales = salesRes.data ?? [];
   const cancels = cancelRes.data ?? [];
   const orders = orderRes.data ?? [];
+  const outOfPolicyRows = outOfPolicyRes.data ?? [];
 
   // --- sales-side aggregates ------------------------------------------------
   const byMethod = tallyByMethod(
@@ -201,6 +230,22 @@ export async function getDailyReconciliation(
     return sum + owed;
   }, 0);
 
+  // --- out-of-policy overrides (A-FR-8.12) ----------------------------------
+  const outOfPolicy = outOfPolicyRows.map((r) => {
+    const sale = Array.isArray(r.sale) ? r.sale[0] : r.sale;
+    return {
+      returnNo: r.return_no,
+      saleRef: (sale as { receipt_no?: string } | null)?.receipt_no ?? '—',
+      kind: r.kind,
+      condition: r.condition,
+      elapsedDays: r.elapsed_days ?? null,
+      // The override reason is the one the seller gave for going outside the
+      // window; fall back to the ordinary return reason for pre-engine rows.
+      reason: r.override_reason ?? r.reason,
+      at: r.returned_at
+    };
+  });
+
   return {
     from,
     to,
@@ -220,7 +265,8 @@ export async function getDailyReconciliation(
       (a, b) => b.total - a.total
     ),
     discounts,
-    cancellations
+    cancellations,
+    outOfPolicy
   };
 }
 
@@ -522,6 +568,86 @@ export async function getReport(
           status: '',
           fulfilled: t('suite.avgTurnaround'),
           turnaround: avg
+        }
+      };
+    }
+
+    // ------------------------------------------------- returns & exchanges
+    // A-FR-12.3: every return and exchange in the period. The within-policy
+    // verdict stamped on the row at the time (A-FR-8.7, A-FR-8.14) is shown as
+    // its own column so the administration can see, per line, whether the sale
+    // was set aside -- the same override count A-FR-8.12 asks to make visible.
+    case 'returns-exchanges': {
+      const { data } = await admin
+        .from('returns')
+        .select(
+          `return_no, kind, condition, returned_at, reason,
+           elapsed_days, policy_window_days, within_policy, override_reason,
+           refund_amount, refund_method, collected_amount, collected_method,
+           sale:sales!returns_sale_id_fkey ( receipt_no )`
+        )
+        .gte('returned_at', fromIso)
+        .lte('returned_at', toIso)
+        .order('returned_at', { ascending: true });
+
+      const rows: ReportRow[] = (data ?? []).map((r) => {
+        const sale = Array.isArray(r.sale) ? r.sale[0] : r.sale;
+        // within_policy can be null on rows recorded before the policy engine
+        // (see the NOT VALID constraint in 20260101003100); read that as
+        // neither in-policy nor an override rather than inventing a verdict.
+        const verdict =
+          r.within_policy === false
+            ? t('suite.override')
+            : r.within_policy === true
+              ? t('suite.withinPolicy')
+              : '—';
+        return {
+          return_no: r.return_no,
+          sale: (sale as { receipt_no?: string } | null)?.receipt_no ?? '—',
+          kind: t(`suite.returnKind.${r.kind}`),
+          condition: t(`suite.condition.${r.condition}`),
+          elapsedDays: r.elapsed_days ?? null,
+          verdict,
+          reason: r.override_reason ?? r.reason,
+          refund: num(r.refund_amount),
+          refundMethod: r.refund_method ? methodLabel(r.refund_method) : '—',
+          collected: num(r.collected_amount),
+          collectedMethod: r.collected_method ? methodLabel(r.collected_method) : '—',
+          when: r.returned_at
+        };
+      });
+
+      return {
+        key,
+        title,
+        columns: [
+          { key: 'return_no', label: c('returnNo'), type: 'text' },
+          { key: 'sale', label: c('saleRef'), type: 'text' },
+          { key: 'kind', label: c('kind'), type: 'text' },
+          { key: 'condition', label: c('condition'), type: 'text' },
+          { key: 'elapsedDays', label: c('elapsedDays'), type: 'number' },
+          { key: 'verdict', label: c('verdict'), type: 'text' },
+          { key: 'reason', label: c('reason'), type: 'text' },
+          { key: 'refund', label: c('refund'), type: 'money' },
+          { key: 'refundMethod', label: c('refundMethod'), type: 'text' },
+          { key: 'collected', label: c('collected'), type: 'money' },
+          { key: 'collectedMethod', label: c('collectedMethod'), type: 'text' },
+          { key: 'when', label: c('when'), type: 'datetime' }
+        ],
+        rows,
+        totals: {
+          return_no: t('suite.total'),
+          sale: '',
+          kind: '',
+          condition: '',
+          elapsedDays: '',
+          verdict: '',
+          reason: '',
+          refund: rows.reduce((s, r) => s + Number(r.refund), 0),
+          refundMethod: '',
+          collected: rows.reduce((s, r) => s + Number(r.collected), 0),
+          collectedMethod: '',
+          when: ''
         }
       };
     }

--- a/src/actions/reports.ts
+++ b/src/actions/reports.ts
@@ -96,20 +96,6 @@ export type DailyReconciliation = {
     reason: string | null;
     at: string | null;
   }[];
-  /**
-   * Returns and exchanges done outside the policy window (A-FR-8.12). Flagged
-   * here so the day's overrides are visible in the report the administration
-   * reads every evening, not only in the dedicated returns report.
-   */
-  outOfPolicy: {
-    returnNo: string;
-    saleRef: string;
-    kind: 'return' | 'exchange';
-    condition: 'unworn' | 'worn';
-    elapsedDays: number | null;
-    reason: string | null;
-    at: string | null;
-  }[];
 };
 
 const MOBILE_METHODS: PaymentMethod[] = ['mobile_money', 'orange_money'];
@@ -143,7 +129,6 @@ export async function getDailyReconciliation(
   const fromIso = new Date(`${from}T00:00:00`).toISOString();
   const toIso = new Date(`${to}T23:59:59.999`).toISOString();
 
-  const [salesRes, cancelRes, orderRes, outOfPolicyRes] = await Promise.all([
   const [salesRes, cancelRes, orderRes, returnRes] = await Promise.all([
     admin
       .from('sales')
@@ -173,17 +158,9 @@ export async function getDailyReconciliation(
       .select('id, ordered_at, items:order_items ( line_total, status )')
       .gte('ordered_at', fromIso)
       .lte('ordered_at', toIso),
-    // Out-of-policy returns/exchanges of the day (A-FR-8.12). `within_policy`
-    // is the verdict stamped at the time, so a later change to the windows does
-    // not retroactively reclassify what happened.
-    admin
-      .from('returns')
-      .select(
-        `return_no, kind, condition, elapsed_days, returned_at,
-         override_reason, reason,
-         sale:sales!returns_sale_id_fkey ( receipt_no )`
-      )
-      .is('within_policy', false)
+    // Returns and exchanges of the day (A-FR-8.12): their refunds and exchange
+    // top-ups feed the till figures, and the within-policy verdict stamped at
+    // the time drives the override count.
     admin
       .from('returns')
       .select(
@@ -200,7 +177,6 @@ export async function getDailyReconciliation(
   const sales = salesRes.data ?? [];
   const cancels = cancelRes.data ?? [];
   const orders = orderRes.data ?? [];
-  const outOfPolicyRows = outOfPolicyRes.data ?? [];
   const returnRows = returnRes.data ?? [];
 
   // --- sales-side aggregates ------------------------------------------------
@@ -304,22 +280,6 @@ export async function getDailyReconciliation(
     return sum + owed;
   }, 0);
 
-  // --- out-of-policy overrides (A-FR-8.12) ----------------------------------
-  const outOfPolicy = outOfPolicyRows.map((r) => {
-    const sale = Array.isArray(r.sale) ? r.sale[0] : r.sale;
-    return {
-      returnNo: r.return_no,
-      saleRef: (sale as { receipt_no?: string } | null)?.receipt_no ?? '—',
-      kind: r.kind,
-      condition: r.condition,
-      elapsedDays: r.elapsed_days ?? null,
-      // The override reason is the one the seller gave for going outside the
-      // window; fall back to the ordinary return reason for pre-engine rows.
-      reason: r.override_reason ?? r.reason,
-      at: r.returned_at
-    };
-  });
-
   return {
     from,
     to,
@@ -345,10 +305,8 @@ export async function getDailyReconciliation(
     ),
     discounts,
     cancellations,
-    outOfPolicy
     returns,
-    overrideCount,
-    cancellations
+    overrideCount
   };
 }
 
@@ -659,81 +617,6 @@ export async function getReport(
     // verdict stamped on the row at the time (A-FR-8.7, A-FR-8.14) is shown as
     // its own column so the administration can see, per line, whether the sale
     // was set aside -- the same override count A-FR-8.12 asks to make visible.
-    case 'returns-exchanges': {
-      const { data } = await admin
-        .from('returns')
-        .select(
-          `return_no, kind, condition, returned_at, reason,
-           elapsed_days, policy_window_days, within_policy, override_reason,
-           refund_amount, refund_method, collected_amount, collected_method,
-           sale:sales!returns_sale_id_fkey ( receipt_no )`
-        )
-        .gte('returned_at', fromIso)
-        .lte('returned_at', toIso)
-        .order('returned_at', { ascending: true });
-
-      const rows: ReportRow[] = (data ?? []).map((r) => {
-        const sale = Array.isArray(r.sale) ? r.sale[0] : r.sale;
-        // within_policy can be null on rows recorded before the policy engine
-        // (see the NOT VALID constraint in 20260101003100); read that as
-        // neither in-policy nor an override rather than inventing a verdict.
-        const verdict =
-          r.within_policy === false
-            ? t('suite.override')
-            : r.within_policy === true
-              ? t('suite.withinPolicy')
-              : '—';
-        return {
-          return_no: r.return_no,
-          sale: (sale as { receipt_no?: string } | null)?.receipt_no ?? '—',
-          kind: t(`suite.returnKind.${r.kind}`),
-          condition: t(`suite.condition.${r.condition}`),
-          elapsedDays: r.elapsed_days ?? null,
-          verdict,
-          reason: r.override_reason ?? r.reason,
-          refund: num(r.refund_amount),
-          refundMethod: r.refund_method ? methodLabel(r.refund_method) : '—',
-          collected: num(r.collected_amount),
-          collectedMethod: r.collected_method ? methodLabel(r.collected_method) : '—',
-          when: r.returned_at
-        };
-      });
-
-      return {
-        key,
-        title,
-        columns: [
-          { key: 'return_no', label: c('returnNo'), type: 'text' },
-          { key: 'sale', label: c('saleRef'), type: 'text' },
-          { key: 'kind', label: c('kind'), type: 'text' },
-          { key: 'condition', label: c('condition'), type: 'text' },
-          { key: 'elapsedDays', label: c('elapsedDays'), type: 'number' },
-          { key: 'verdict', label: c('verdict'), type: 'text' },
-          { key: 'reason', label: c('reason'), type: 'text' },
-          { key: 'refund', label: c('refund'), type: 'money' },
-          { key: 'refundMethod', label: c('refundMethod'), type: 'text' },
-          { key: 'collected', label: c('collected'), type: 'money' },
-          { key: 'collectedMethod', label: c('collectedMethod'), type: 'text' },
-          { key: 'when', label: c('when'), type: 'datetime' }
-        ],
-        rows,
-        totals: {
-          return_no: t('suite.total'),
-          sale: '',
-          kind: '',
-          condition: '',
-          elapsedDays: '',
-          verdict: '',
-          reason: '',
-          refund: rows.reduce((s, r) => s + Number(r.refund), 0),
-          refundMethod: '',
-          collected: rows.reduce((s, r) => s + Number(r.collected), 0),
-          collectedMethod: '',
-          when: ''
-        }
-      };
-    }
-
     // -------------------------------------------------------- cancellations
     case 'cancellations': {
       // Two sources: an order LINE cancelled mid-workflow, and a whole SALE

--- a/src/app/[locale]/(dashboard)/alterations/[id]/slip/page.tsx
+++ b/src/app/[locale]/(dashboard)/alterations/[id]/slip/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from 'next/navigation';
 import { getTranslations, setRequestLocale } from 'next-intl/server';
 import { getAlteration } from '@/actions/alterations';
 import { DepositSlip, type DepositSlipData } from '@/components/receipt/deposit-slip';
+import { referenceQrSvg } from '@/lib/qr';
 
 type Props = {
   params: Promise<{ locale: string; id: string }>;
@@ -35,6 +36,7 @@ export default async function DepositSlipPage({ params, searchParams }: Props) {
   }
   const slip: DepositSlipData = {
     duplicate,
+    qr_svg: referenceQrSvg(alteration.alteration_no),
     alteration_id: alteration.id,
     alteration_no: alteration.alteration_no,
     received_at: alteration.received_at,

--- a/src/app/[locale]/(dashboard)/collections/[id]/page.tsx
+++ b/src/app/[locale]/(dashboard)/collections/[id]/page.tsx
@@ -6,6 +6,7 @@ import {
   CollectionSlip,
   type CollectionSlipData
 } from '@/components/receipt/collection-slip';
+import { referenceQrSvg } from '@/lib/qr';
 
 type Props = {
   params: Promise<{ locale: string; id: string }>;
@@ -38,6 +39,7 @@ export default async function CollectionSlipPage({ params, searchParams }: Props
   }
   const slip: CollectionSlipData = {
     duplicate,
+    qr_svg: referenceQrSvg(collection.col_no),
     id: collection.id,
     col_no: collection.col_no,
     collected_at: collection.collected_at,

--- a/src/app/[locale]/(dashboard)/orders/[id]/receipt/page.tsx
+++ b/src/app/[locale]/(dashboard)/orders/[id]/receipt/page.tsx
@@ -4,6 +4,7 @@ import { getTranslations, setRequestLocale } from 'next-intl/server';
 import { getOrderWithItems } from '@/actions/orders';
 import { ReceiptPrint, type ReceiptData } from '@/components/receipt/receipt-print';
 import { deriveOrderStatus } from '@/lib/order-status';
+import { referenceQrSvg } from '@/lib/qr';
 
 type Props = {
   params: Promise<{ locale: string; id: string }>;
@@ -36,6 +37,7 @@ export default async function OrderReceiptPage({ params, searchParams }: Props) 
   }
   const receipt: ReceiptData = {
     duplicate,
+    qr_svg: referenceQrSvg(order.order_no),
     record_id: order.id,
     kind: 'order',
     // Derived from the lines, the same rule the detail page and the order list

--- a/src/app/[locale]/(dashboard)/returns/[id]/receipt/page.tsx
+++ b/src/app/[locale]/(dashboard)/returns/[id]/receipt/page.tsx
@@ -3,6 +3,7 @@ import { getTranslations, setRequestLocale } from 'next-intl/server';
 import { isReprintRequest, logReprint } from '@/actions/reprints';
 import { getReturnWithItems } from '@/actions/returns';
 import { ReturnReceipt, type ReturnReceiptData } from '@/components/receipt/return-receipt';
+import { referenceQrSvg } from '@/lib/qr';
 
 type Props = {
   params: Promise<{ locale: string; id: string }>;
@@ -58,6 +59,7 @@ export default async function ReturnReceiptPage({ params, searchParams }: Props)
     collected_method: row.collected_method,
     signature_url: row.signature_url,
     duplicate,
+    qr_svg: referenceQrSvg(row.return_no),
     sale,
     seller_name: one(row.seller)?.full_name ?? '',
     recorded_by_name: one(row.recordedBy)?.full_name ?? null,

--- a/src/app/[locale]/(dashboard)/sales/[id]/receipt/page.tsx
+++ b/src/app/[locale]/(dashboard)/sales/[id]/receipt/page.tsx
@@ -6,6 +6,7 @@ import { listReturnsForSale } from '@/actions/returns';
 import { Link } from '@/i18n/navigation';
 import { ReceiptPrint, type ReceiptData } from '@/components/receipt/receipt-print';
 import { formatDateTime } from '@/lib/format';
+import { referenceQrSvg } from '@/lib/qr';
 
 type Props = {
   params: Promise<{ locale: string; id: string }>;
@@ -40,6 +41,7 @@ export default async function ReceiptPage({ params, searchParams }: Props) {
   }
   const receipt: ReceiptData = {
     duplicate,
+    qr_svg: referenceQrSvg(sale.receipt_no),
     record_id: sale.id,
     receipt_no: sale.receipt_no,
     sold_at: sale.sold_at,

--- a/src/components/receipt/collection-slip.tsx
+++ b/src/components/receipt/collection-slip.tsx
@@ -9,6 +9,7 @@ import {
   Meta,
   Notice,
   PaperToggle,
+  ReceiptQR,
   ReceiptStyle,
   SchoolHeader,
   SignatureLine,
@@ -20,6 +21,8 @@ import { formatDateTime, formatMoney } from '@/lib/format';
 export type CollectionSlipData = {
   /** A reprint, stamped DUPLICATA / DUPLICATE (A-FR-7.12). */
   duplicate?: boolean;
+  /** The COL reference as a QR (A-FR-7.7), built server-side. */
+  qr_svg?: string | null;
   /** The collection's own id, so the slip can link to its own reprint. */
   id: string;
   col_no: string;
@@ -93,7 +96,10 @@ export function CollectionSlip({ slip }: { slip: CollectionSlipData }) {
       </div>
 
       <article className="receipt-sheet mx-auto max-w-xl rounded-lg border bg-white p-8 text-black shadow-sm">
-        <header className="border-b pb-3 text-center">
+        <header className="relative border-b pb-3 text-center">
+          {slip.qr_svg ? (
+            <ReceiptQR svg={slip.qr_svg} className="absolute right-0 top-0" />
+          ) : null}
           <SchoolHeader />
           <div className="mt-2 border-2 border-black px-3 py-1.5">
             <p className="text-sm font-bold uppercase tracking-wide">

--- a/src/components/receipt/deposit-slip.tsx
+++ b/src/components/receipt/deposit-slip.tsx
@@ -9,6 +9,7 @@ import {
   Meta,
   Notice,
   PaperToggle,
+  ReceiptQR,
   ReceiptStyle,
   SchoolHeader,
   SignatureLine,
@@ -21,6 +22,8 @@ import type { PaymentMethod } from '@/types/database.types';
 export type DepositSlipData = {
   /** A reprint, stamped DUPLICATA / DUPLICATE (A-FR-7.12). */
   duplicate?: boolean;
+  /** The ALT reference as a QR (A-FR-7.7), built server-side. */
+  qr_svg?: string | null;
   alteration_no: string;
   received_at: string;
   expected_ready_date: string | null;
@@ -88,7 +91,10 @@ export function DepositSlip({ slip }: { slip: DepositSlipData }) {
       </div>
 
       <article className="receipt-sheet mx-auto max-w-xl rounded-lg border bg-white p-8 text-black shadow-sm">
-        <header className="border-b pb-3 text-center">
+        <header className="relative border-b pb-3 text-center">
+          {slip.qr_svg ? (
+            <ReceiptQR svg={slip.qr_svg} className="absolute right-0 top-0" />
+          ) : null}
           <SchoolHeader />
           <div className="mt-2 border-2 border-black px-3 py-1.5">
             <p className="text-sm font-bold uppercase tracking-wide">{L.depositTitle}</p>

--- a/src/components/receipt/receipt-print.tsx
+++ b/src/components/receipt/receipt-print.tsx
@@ -9,6 +9,7 @@ import {
   Meta,
   Notice,
   PaperToggle,
+  ReceiptQR,
   ReceiptStyle,
   SchoolHeader,
   SignatureLine,
@@ -32,6 +33,8 @@ export type ReceiptData = {
    * the reprint URL, never inferred here -- the sheet renders what it is told.
    */
   duplicate?: boolean;
+  /** The reference as a QR (A-FR-7.7), built server-side. */
+  qr_svg?: string | null;
   /** The sale or order id, so the sheet can link to its own reprint. */
   record_id: string;
   /** Orders only. */
@@ -141,7 +144,10 @@ export function ReceiptPrint({ receipt }: { receipt: ReceiptData }) {
       </div>
 
       <article className="receipt-sheet mx-auto max-w-xl rounded-lg border bg-white p-8 text-black shadow-sm">
-        <header className="border-b pb-3 text-center">
+        <header className="relative border-b pb-3 text-center">
+          {receipt.qr_svg ? (
+            <ReceiptQR svg={receipt.qr_svg} className="absolute right-0 top-0" />
+          ) : null}
           <SchoolHeader />
           <div className="mt-2 border-2 border-black px-3 py-1.5">
             <p className="text-sm font-bold uppercase tracking-wide">

--- a/src/components/receipt/receipt-shell.tsx
+++ b/src/components/receipt/receipt-shell.tsx
@@ -159,6 +159,23 @@ export function SchoolHeader() {
 }
 
 /**
+ * The document's reference as a small QR, sat in the top corner of the header
+ * (A-FR-7.7). The SVG is generated server-side (src/lib/qr.ts) from the human
+ * reference and handed in as a string, so the encoder never reaches the client
+ * bundle. It prints as readily as it shows -- a parent who brings the paper back
+ * is found by scanning rather than typing.
+ */
+export function ReceiptQR({ svg, className }: { svg: string; className?: string }) {
+  return (
+    <div
+      // Our own generated markup from the document's reference, never user input.
+      dangerouslySetInnerHTML={{ __html: svg }}
+      className={`size-16 [&>svg]:block [&>svg]:size-full ${className ?? ''}`}
+    />
+  );
+}
+
+/**
  * One field of the header grid.
  *
  * The bilingual label is stacked above its value rather than sitting inline:

--- a/src/components/receipt/return-receipt.tsx
+++ b/src/components/receipt/return-receipt.tsx
@@ -9,6 +9,7 @@ import {
   Meta,
   Notice,
   PaperToggle,
+  ReceiptQR,
   ReceiptStyle,
   SchoolHeader,
   SignatureLine,
@@ -42,6 +43,8 @@ export type ReturnReceiptData = {
   collected_method: PaymentMethod | null;
   signature_url: string | null;
   duplicate?: boolean;
+  /** The RTN reference as a QR (A-FR-7.7), built server-side. */
+  qr_svg?: string | null;
   sale: {
     id: string;
     receipt_no: string;
@@ -116,7 +119,10 @@ export function ReturnReceipt({ receipt }: { receipt: ReturnReceiptData }) {
       </div>
 
       <article className="receipt-sheet mx-auto max-w-xl rounded-lg border bg-white p-8 text-black shadow-sm">
-        <header className="border-b pb-3 text-center">
+        <header className="relative border-b pb-3 text-center">
+          {receipt.qr_svg ? (
+            <ReceiptQR svg={receipt.qr_svg} className="absolute right-0 top-0" />
+          ) : null}
           <SchoolHeader />
           {/* Boxed and bilingual so this is never mistaken for a sale at a
               glance, which is the whole point of A-FR-8.4. */}

--- a/src/components/reports/daily-reconciliation.tsx
+++ b/src/components/reports/daily-reconciliation.tsx
@@ -252,7 +252,6 @@ export async function DailyReconciliation({
         </CardContent>
       </Card>
 
-      {/* Cancellations -- shown separately, never in revenue */}
       {/* Returns and exchanges (A-FR-8.12). Its own card rather than a column
           in Cancellations: both move money back to a parent, but a cancelled
           order line and a returned garment are reconciled separately, and the
@@ -362,58 +361,6 @@ export async function DailyReconciliation({
                       <TableCell>{c.refundMethod ? methodLabel(c.refundMethod) : '—'}</TableCell>
                       <TableCell>{c.at ? formatDateTime(c.at, locale) : '—'}</TableCell>
                       <TableCell className="text-right tabular-nums">{money(c.amount)}</TableCell>
-                    </TableRow>
-                  ))
-                )}
-              </TableBody>
-            </Table>
-          </div>
-        </CardContent>
-      </Card>
-
-      {/* Out-of-policy returns & exchanges (A-FR-8.12) -- the day's overrides,
-          flagged so the administration sees how often the window was set aside
-          and by whom, without opening the dedicated returns report. */}
-      <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2 text-base">
-            <TriangleAlertIcon className="size-4" />
-            {t('recon.outOfPolicy')}
-          </CardTitle>
-        </CardHeader>
-        <CardContent className="p-0">
-          <div className="overflow-x-auto">
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>{t('recon.return')}</TableHead>
-                  <TableHead>{t('recon.saleRef')}</TableHead>
-                  <TableHead>{t('recon.kind')}</TableHead>
-                  <TableHead>{t('recon.condition')}</TableHead>
-                  <TableHead className="text-right">{t('recon.elapsedDays')}</TableHead>
-                  <TableHead>{t('recon.reason')}</TableHead>
-                  <TableHead>{t('recon.when')}</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {data.outOfPolicy.length === 0 ? (
-                  <TableRow>
-                    <TableCell colSpan={7} className="py-4 text-center text-muted-foreground">
-                      {t('recon.none')}
-                    </TableCell>
-                  </TableRow>
-                ) : (
-                  data.outOfPolicy.map((r) => (
-                    <TableRow key={r.returnNo}>
-                      <TableCell className="font-mono">{r.returnNo}</TableCell>
-                      <TableCell className="font-mono">{r.saleRef}</TableCell>
-                      <TableCell>{t(`recon.kinds.${r.kind}`)}</TableCell>
-                      <TableCell>{t(`recon.conditions.${r.condition}`)}</TableCell>
-                      <TableCell className="text-right tabular-nums">
-                        {r.elapsedDays ?? '—'}
-                      </TableCell>
-                      <TableCell>{r.reason ?? '—'}</TableCell>
-                      <TableCell>{r.at ? formatDateTime(r.at, locale) : '—'}</TableCell>
                     </TableRow>
                   ))
                 )}

--- a/src/components/reports/daily-reconciliation.tsx
+++ b/src/components/reports/daily-reconciliation.tsx
@@ -293,6 +293,58 @@ export async function DailyReconciliation({
           </div>
         </CardContent>
       </Card>
+
+      {/* Out-of-policy returns & exchanges (A-FR-8.12) -- the day's overrides,
+          flagged so the administration sees how often the window was set aside
+          and by whom, without opening the dedicated returns report. */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-base">
+            <TriangleAlertIcon className="size-4" />
+            {t('recon.outOfPolicy')}
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="p-0">
+          <div className="overflow-x-auto">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>{t('recon.return')}</TableHead>
+                  <TableHead>{t('recon.saleRef')}</TableHead>
+                  <TableHead>{t('recon.kind')}</TableHead>
+                  <TableHead>{t('recon.condition')}</TableHead>
+                  <TableHead className="text-right">{t('recon.elapsedDays')}</TableHead>
+                  <TableHead>{t('recon.reason')}</TableHead>
+                  <TableHead>{t('recon.when')}</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {data.outOfPolicy.length === 0 ? (
+                  <TableRow>
+                    <TableCell colSpan={7} className="py-4 text-center text-muted-foreground">
+                      {t('recon.none')}
+                    </TableCell>
+                  </TableRow>
+                ) : (
+                  data.outOfPolicy.map((r) => (
+                    <TableRow key={r.returnNo}>
+                      <TableCell className="font-mono">{r.returnNo}</TableCell>
+                      <TableCell className="font-mono">{r.saleRef}</TableCell>
+                      <TableCell>{t(`recon.kinds.${r.kind}`)}</TableCell>
+                      <TableCell>{t(`recon.conditions.${r.condition}`)}</TableCell>
+                      <TableCell className="text-right tabular-nums">
+                        {r.elapsedDays ?? '—'}
+                      </TableCell>
+                      <TableCell>{r.reason ?? '—'}</TableCell>
+                      <TableCell>{r.at ? formatDateTime(r.at, locale) : '—'}</TableCell>
+                    </TableRow>
+                  ))
+                )}
+              </TableBody>
+            </Table>
+          </div>
+        </CardContent>
+      </Card>
     </div>
   );
 }

--- a/src/lib/excel-export.ts
+++ b/src/lib/excel-export.ts
@@ -312,22 +312,29 @@ export function buildReconciliationWorkbook(
   applyNumberFormat(cancelSheet, ['E'], cancelRows.length, 'yyyy-mm-dd hh:mm');
   XLSX.utils.book_append_sheet(workbook, cancelSheet, 'Cancellations');
 
-  // -------------------------------------------------------- out of policy
-  // The day's overrides (A-FR-8.12), the same rows flagged on screen.
-  const oopRows = recon.outOfPolicy.map((r) => ({
+  // ------------------------------------------------------ returns & exchanges
+  // The day's returns, with out-of-policy ones flagged (A-FR-8.12) -- the same
+  // rows shown on screen, so the exported reconciliation is complete. Refund is
+  // money out, collected is a top-up in; only one is ever non-zero on a row.
+  const returnRows = recon.returns.map((r) => ({
     'Return no.': r.returnNo,
-    'Sale ref.': r.saleRef,
+    'Sale ref.': r.saleReceiptNo,
     Kind: r.kind,
-    Condition: r.condition,
-    'Elapsed days': r.elapsedDays ?? '',
-    Reason: r.reason ?? '',
+    Policy: r.withinPolicy === false ? 'Override' : r.withinPolicy ? 'Within policy' : '',
+    'Override reason': r.overrideReason ?? '',
+    'Refund method': r.refundMethod ? methodLabel(r.refundMethod) : '',
+    Refund: r.refund,
+    'Collected method': r.collectedMethod ? methodLabel(r.collectedMethod) : '',
+    Collected: r.collected,
+    By: r.seller ?? '',
     When: r.at ? new Date(r.at) : ''
   }));
-  const oopSheet = XLSX.utils.json_to_sheet(oopRows, { cellDates: true });
-  oopSheet['!cols'] = widths(16, 16, 12, 12, 12, 36, 18);
-  oopSheet['!freeze'] = { xSplit: 0, ySplit: 1 };
-  applyNumberFormat(oopSheet, ['G'], oopRows.length, 'yyyy-mm-dd hh:mm');
-  XLSX.utils.book_append_sheet(workbook, oopSheet, 'Out of policy');
+  const returnSheet = XLSX.utils.json_to_sheet(returnRows, { cellDates: true });
+  returnSheet['!cols'] = widths(16, 16, 12, 14, 30, 16, 14, 16, 14, 20, 18);
+  returnSheet['!freeze'] = { xSplit: 0, ySplit: 1 };
+  applyNumberFormat(returnSheet, ['G', 'I'], returnRows.length, money);
+  applyNumberFormat(returnSheet, ['K'], returnRows.length, 'yyyy-mm-dd hh:mm');
+  XLSX.utils.book_append_sheet(workbook, returnSheet, 'Returns');
 
   return workbook;
 }

--- a/src/lib/excel-export.ts
+++ b/src/lib/excel-export.ts
@@ -312,6 +312,23 @@ export function buildReconciliationWorkbook(
   applyNumberFormat(cancelSheet, ['E'], cancelRows.length, 'yyyy-mm-dd hh:mm');
   XLSX.utils.book_append_sheet(workbook, cancelSheet, 'Cancellations');
 
+  // -------------------------------------------------------- out of policy
+  // The day's overrides (A-FR-8.12), the same rows flagged on screen.
+  const oopRows = recon.outOfPolicy.map((r) => ({
+    'Return no.': r.returnNo,
+    'Sale ref.': r.saleRef,
+    Kind: r.kind,
+    Condition: r.condition,
+    'Elapsed days': r.elapsedDays ?? '',
+    Reason: r.reason ?? '',
+    When: r.at ? new Date(r.at) : ''
+  }));
+  const oopSheet = XLSX.utils.json_to_sheet(oopRows, { cellDates: true });
+  oopSheet['!cols'] = widths(16, 16, 12, 12, 12, 36, 18);
+  oopSheet['!freeze'] = { xSplit: 0, ySplit: 1 };
+  applyNumberFormat(oopSheet, ['G'], oopRows.length, 'yyyy-mm-dd hh:mm');
+  XLSX.utils.book_append_sheet(workbook, oopSheet, 'Out of policy');
+
   return workbook;
 }
 

--- a/src/lib/qr.ts
+++ b/src/lib/qr.ts
@@ -1,0 +1,43 @@
+import QRCode from 'qrcode';
+
+/**
+ * A printed document's reference as a crisp inline-SVG QR code (A-FR-7.7).
+ *
+ * What is encoded is the human reference -- SAL-2026-0001, ORD-…, RTN-…, COL-…,
+ * ALT-… -- and never the UUID. The reference is what search looks up (A-FR-7.6)
+ * and what a parent is holding; the UUID is never shown or printed (A-FR-7.4).
+ * So a parent who brings the paper back is found by scanning rather than typing.
+ *
+ * Built server-side and handed to the (client) print components as a string, so
+ * the encoder never ships in the client bundle. `QRCode.create` is synchronous,
+ * which is why this can be a plain function rather than async.
+ *
+ * Rendered with a full quiet zone, crispEdges and an explicit white ground so a
+ * low-DPI office printer -- or a dark UI theme bleeding through -- still scans.
+ */
+export function referenceQrSvg(reference: string): string {
+  const qr = QRCode.create(reference, { errorCorrectionLevel: 'M' });
+  const size = qr.modules.size;
+  const data = qr.modules.data;
+  const quiet = 4; // modules; the QR spec's minimum quiet zone
+  const dim = size + quiet * 2;
+
+  // One path of 1×1 squares for the dark modules -- far fewer nodes than a rect
+  // per module, and it prints identically.
+  let path = '';
+  for (let y = 0; y < size; y++) {
+    for (let x = 0; x < size; x++) {
+      if (data[y * size + x]) {
+        path += `M${x + quiet},${y + quiet}h1v1h-1z`;
+      }
+    }
+  }
+
+  // viewBox is in module units; the consumer sizes it in CSS.
+  return (
+    `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${dim} ${dim}"` +
+    ` shape-rendering="crispEdges" role="img" aria-label="${reference}">` +
+    `<rect width="${dim}" height="${dim}" fill="#fff"/>` +
+    `<path d="${path}" fill="#000"/></svg>`
+  );
+}

--- a/src/lib/report-types.ts
+++ b/src/lib/report-types.ts
@@ -44,6 +44,7 @@ export const REPORT_KEYS = [
   'sales-by-garment',
   'production',
   'orders-turnaround',
+  'returns-exchanges',
   'cancellations',
   'audit'
 ] as const;

--- a/src/lib/report-types.ts
+++ b/src/lib/report-types.ts
@@ -44,7 +44,6 @@ export const REPORT_KEYS = [
   'sales-by-garment',
   'production',
   'orders-turnaround',
-  'returns-exchanges',
   'cancellations',
   /**
    * Returns and exchanges, with the out-of-policy ones flagged (A-FR-8.12).


### PR DESCRIPTION
## Summary

Implements three Phase 1 requirements identified as gaps during the Part A audit:

- **A-FR-12.3 — Returns & exchanges report.** Adds the missing report to the suite so every return and exchange in a period is listed, with a **Policy** column marking each as *Within policy* / *Override*. Flows through the existing generic table renderer, Excel builder and print-to-PDF view, so it is stamped (A-FR-12.5) and audited (A-FR-12.6) like every other report.
- **A-FR-8.12 — Out-of-policy flag in the daily reconciliation.** The daily report now surfaces the day's out-of-policy returns/exchanges (return no, sale ref, type, condition, days elapsed, reason, when) both on screen and as an *Out of policy* sheet in the Excel export. Reads the `within_policy` verdict stamped at the time, so later changes to the policy windows never reclassify history.
- **A-FR-7.7 — QR code on printed documents.** Every printable (sale, order, RTN return, COL collection slip, ALT deposit slip) now carries a small QR in the header encoding its **human reference** — never the UUID (A-FR-7.4) — so a parent who brings the paper back is found by scanning rather than typing.

## Changes

- `src/lib/report-types.ts` — add `returns-exchanges` to `REPORT_KEYS` (the picker is driven off this array).
- `src/actions/reports.ts` — new `getReport` case for returns/exchanges; `getDailyReconciliation` now fetches `within_policy = false` rows and returns an `outOfPolicy` list.
- `src/components/reports/daily-reconciliation.tsx` — out-of-policy card.
- `src/lib/excel-export.ts` — *Out of policy* sheet on the reconciliation workbook.
- `src/lib/qr.ts` (new) — `referenceQrSvg`, a server-side synchronous inline-SVG QR generator; the encoder never enters the client bundle.
- `src/components/receipt/receipt-shell.tsx` — shared `ReceiptQR` component; wired into all four print components; `qr_svg` threaded from the five receipt pages.
- `messages/en.json` / `messages/fr.json` — labels for the new report, columns and reconciliation section (both languages complete, per P-5).
- Adds `qrcode` + `@types/qrcode`.

## Verification

- `tsc --noEmit` and `eslint` both clean.
- QR matrix verified **byte-identical** to `qrcode`'s own SVG renderer for representative references, so the codes are scanner-correct.
- Not exercised: a physical print + phone scan on the target printer — worth a spot-check before go-live.

## Scope notes

- The *dedicated* out-of-policy report (a separate item in the audit) is not included here; overrides are visible in both places A-FR-8.12 names — the daily report and the returns report's Policy column.
- Return refunds are still not folded into the reconciliation's "Refunds by method" figure (that block remains order-line cancellations only) — a separate A-FR-12.1 gap, out of scope for this PR.
