### PR TITLE
PR/feat(admin): account activate/deactivate/delete, seller order visibility, full-month ranges, support alerts

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -94,7 +94,19 @@
     "resetPassword": "Reset password",
     "resetFailed": "Could not reset the password.",
     "resetDoneTitle": "Temporary password set",
-    "resetDoneBody": "Share this with {name} securely. They must change it at next login."
+    "resetDoneBody": "Share this with {name} securely. They must change it at next login.",
+    "deactivate": "Deactivate",
+    "activate": "Activate",
+    "delete": "Delete",
+    "cancel": "Cancel",
+    "deleteConfirmTitle": "Delete this account?",
+    "deleteConfirmBody": "{name} will be removed permanently. If the account has any activity on record, delete is refused — deactivate it instead so their name stays on what they did.",
+    "deactivatedToast": "{name} deactivated.",
+    "activatedToast": "{name} activated.",
+    "deletedToast": "{name} deleted.",
+    "cannotSelf": "You cannot do that to your own account.",
+    "hasActivity": "This account has activity on record and cannot be deleted. Deactivate it instead.",
+    "actionFailed": "Could not complete that action."
   },
   "Notifications": {
     "title": "Notifications",
@@ -114,7 +126,8 @@
       "sale_recorded": { "title": "New sale", "body": "{receipt} · {total}" },
       "sale_cancelled": { "title": "Sale cancelled", "body": "{receipt}" },
       "order_placed": { "title": "New order", "body": "{order}" },
-      "price_changed": { "title": "Price changed", "body": "{product}" }
+      "price_changed": { "title": "Price changed", "body": "{product}" },
+      "bug_reported": { "title": "Support message", "body": "From {reporter} — tap to read" }
     }
   },
   "Audit": {
@@ -154,6 +167,9 @@
       "stock_movement": "Stock movement",
       "account_created": "Account created",
       "account_password_reset": "Password reset",
+      "account_activated": "Account activated",
+      "account_deactivated": "Account deactivated",
+      "account_deleted": "Account deleted",
       "profile_updated": "Profile updated",
       "password_changed": "Password changed"
     }
@@ -321,6 +337,7 @@
     "invalidCredentials": "Incorrect email or password.",
     "unexpectedError": "Something went wrong. Please try again.",
     "tooManyAttempts": "Too many failed attempts. Try again in a few minutes.",
+    "accountInactive": "This account has been deactivated. Contact your administrator.",
     "sessionExpired": "Your session expired. Please sign in again."
   },
   "Search": {

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -94,7 +94,19 @@
     "resetPassword": "R\u00e9initialiser le mot de passe",
     "resetFailed": "Impossible de r\u00e9initialiser le mot de passe.",
     "resetDoneTitle": "Mot de passe temporaire d\u00e9fini",
-    "resetDoneBody": "Partagez-le avec {name} de fa\u00e7on s\u00e9curis\u00e9e. Il devra le changer \u00e0 la prochaine connexion."
+    "resetDoneBody": "Partagez-le avec {name} de fa\u00e7on s\u00e9curis\u00e9e. Il devra le changer \u00e0 la prochaine connexion.",
+    "deactivate": "D\u00e9sactiver",
+    "activate": "Activer",
+    "delete": "Supprimer",
+    "cancel": "Annuler",
+    "deleteConfirmTitle": "Supprimer ce compte ?",
+    "deleteConfirmBody": "{name} sera supprim\u00e9 d\u00e9finitivement. Si le compte a une activit\u00e9 enregistr\u00e9e, la suppression est refus\u00e9e \u2014 d\u00e9sactivez-le plut\u00f4t afin que son nom reste attach\u00e9 \u00e0 ce qu'il a fait.",
+    "deactivatedToast": "{name} d\u00e9sactiv\u00e9.",
+    "activatedToast": "{name} activ\u00e9.",
+    "deletedToast": "{name} supprim\u00e9.",
+    "cannotSelf": "Vous ne pouvez pas faire cela sur votre propre compte.",
+    "hasActivity": "Ce compte a une activit\u00e9 enregistr\u00e9e et ne peut pas \u00eatre supprim\u00e9. D\u00e9sactivez-le plut\u00f4t.",
+    "actionFailed": "Impossible d'effectuer cette action."
   },
   "Notifications": {
     "title": "Notifications",
@@ -114,7 +126,8 @@
       "sale_recorded": { "title": "Nouvelle vente", "body": "{receipt} \u00b7 {total}" },
       "sale_cancelled": { "title": "Vente annul\u00e9e", "body": "{receipt}" },
       "order_placed": { "title": "Nouvelle commande", "body": "{order}" },
-      "price_changed": { "title": "Prix modifi\u00e9", "body": "{product}" }
+      "price_changed": { "title": "Prix modifi\u00e9", "body": "{product}" },
+      "bug_reported": { "title": "Message d'assistance", "body": "De {reporter} \u2014 appuyez pour lire" }
     }
   },
   "Audit": {
@@ -154,6 +167,9 @@
       "stock_movement": "Mouvement de stock",
       "account_created": "Compte cr\u00e9\u00e9",
       "account_password_reset": "Mot de passe r\u00e9initialis\u00e9",
+      "account_activated": "Compte activ\u00e9",
+      "account_deactivated": "Compte d\u00e9sactiv\u00e9",
+      "account_deleted": "Compte supprim\u00e9",
       "profile_updated": "Profil mis \u00e0 jour",
       "password_changed": "Mot de passe modifi\u00e9"
     }
@@ -321,6 +337,7 @@
     "invalidCredentials": "E-mail ou mot de passe incorrect.",
     "unexpectedError": "Une erreur est survenue. Veuillez r\u00e9essayer.",
     "tooManyAttempts": "Trop de tentatives \u00e9chou\u00e9es. R\u00e9essayez dans quelques minutes.",
+    "accountInactive": "Ce compte a \u00e9t\u00e9 d\u00e9sactiv\u00e9. Contactez votre administrateur.",
     "sessionExpired": "Votre session a expir\u00e9. Veuillez vous reconnecter."
   },
   "Search": {

--- a/src/actions/accounts.ts
+++ b/src/actions/accounts.ts
@@ -84,6 +84,92 @@ export async function createAccount(
   return { ok: true, email };
 }
 
+export type AccountActionResult = { ok: true } | { ok: false; error: string };
+
+/** The caller's id iff they are a Super Admin, else null (checked server-side). */
+async function requireSuperAdmin(): Promise<string | null> {
+  const supabase = await createClient();
+  const {
+    data: { user }
+  } = await supabase.auth.getUser();
+  if (!user) return null;
+  const { data: me } = await supabase.from('profiles').select('role').eq('id', user.id).single();
+  return me?.role === 'super_admin' ? user.id : null;
+}
+
+/**
+ * Activate or deactivate an account (A-FR-P4). A deactivated user cannot log in
+ * (enforced in the login action), but the row stays and their name remains
+ * attached to everything they did -- deactivation is not deletion.
+ *
+ * Super-Admin only, enforced server-side. You cannot deactivate your own
+ * account: locking the only Super Admin out of the system is not a mistake the
+ * UI should allow. Audited (A-FR-11.1).
+ */
+export async function setAccountActive(
+  userId: string,
+  active: boolean
+): Promise<AccountActionResult> {
+  const uid = await requireSuperAdmin();
+  if (!uid) return { ok: false, error: 'forbidden' };
+  if (userId === uid) return { ok: false, error: 'cannotSelf' };
+
+  const admin = createAdminClient();
+  const { error } = await admin.from('profiles').update({ is_active: active }).eq('id', userId);
+  if (error) return { ok: false, error: error.message };
+
+  await logAudit({
+    actorId: uid,
+    action: active ? 'account_activated' : 'account_deactivated',
+    targetTable: 'profiles',
+    targetId: userId,
+    newValue: { is_active: active }
+  });
+
+  revalidatePath('/', 'layout');
+  return { ok: true };
+}
+
+/**
+ * Delete an account outright. Super-Admin only. You cannot delete your own.
+ *
+ * Deleting the auth user cascades to its profile -- but a profile whose name is
+ * attached to sales, orders, movements or returns is protected by a foreign key
+ * (on delete restrict), so the delete fails and the account should be
+ * deactivated instead (P-4). That failure is surfaced as `hasActivity` so the
+ * UI can say so rather than showing a raw database error.
+ */
+export async function deleteAccount(userId: string): Promise<AccountActionResult> {
+  const uid = await requireSuperAdmin();
+  if (!uid) return { ok: false, error: 'forbidden' };
+  if (userId === uid) return { ok: false, error: 'cannotSelf' };
+
+  const admin = createAdminClient();
+  // Captured before deletion so the audit row still says who was removed.
+  const { data: target } = await admin
+    .from('profiles')
+    .select('full_name, role')
+    .eq('id', userId)
+    .single();
+
+  const { error } = await admin.auth.admin.deleteUser(userId);
+  if (error) {
+    // Almost always an FK restriction: the account has activity on record.
+    return { ok: false, error: 'hasActivity' };
+  }
+
+  await logAudit({
+    actorId: uid,
+    action: 'account_deleted',
+    targetTable: 'profiles',
+    targetId: userId,
+    previousValue: target ?? null
+  });
+
+  revalidatePath('/', 'layout');
+  return { ok: true };
+}
+
 function genTempPassword() {
   const letters = 'abcdefghjkmnpqrstuvwxyz';
   const pick = (n: number) =>

--- a/src/actions/auth.ts
+++ b/src/actions/auth.ts
@@ -67,6 +67,20 @@ export async function signIn(
     return { error: 'invalidCredentials', fieldErrors: {} };
   }
 
+  // A-FR-P4: a deactivated account cannot log in. Credentials still verify (so we
+  // do not leak whether the address exists), but the session is dropped
+  // immediately and login is refused.
+  const { data: prof } = await supabase
+    .from('profiles')
+    .select('is_active')
+    .eq('id', data.user!.id)
+    .single();
+  if (prof && !prof.is_active) {
+    await supabase.auth.signOut();
+    await logAudit({ action: 'login_blocked', ip, meta: { email, reason: 'inactive' } });
+    return { error: 'accountInactive', fieldErrors: {} };
+  }
+
   await logAudit({ actorId: data.user?.id ?? null, action: 'login_success', ip, meta: { email } });
 
   // Stamp the session start so the proxy can enforce a per-role timeout.

--- a/src/actions/bug-reports.ts
+++ b/src/actions/bug-reports.ts
@@ -3,6 +3,7 @@
 import { revalidatePath } from 'next/cache';
 import { z } from 'zod';
 import { createClient } from '@/lib/supabase/server';
+import { notify } from '@/lib/notify';
 
 /**
  * In-app bug reports: the failures Sentry never sees.
@@ -78,6 +79,17 @@ export async function submitBugReport(
   });
 
   if (error) return { ok: false, error: error.message };
+
+  // Send it to the people who action reports so it is not just sitting on a
+  // page nobody thought to open (the Super Admin, and Maintenance who read the
+  // same list). Best-effort -- a failed notification never fails the report.
+  await notify({
+    type: 'bug_reported',
+    recipients: { kind: 'roles', roles: ['maintenance', 'super_admin'] },
+    excludeActorId: user.id,
+    data: { reporter: profile?.full_name ?? user.email ?? 'A user' },
+    link: '/bug-reports'
+  });
 
   revalidatePath('/bug-reports', 'page');
   return { ok: true };

--- a/src/app/[locale]/(dashboard)/accounts/page.tsx
+++ b/src/app/[locale]/(dashboard)/accounts/page.tsx
@@ -4,6 +4,7 @@ import { getProfile } from '@/actions/auth';
 import { createAdminClient } from '@/lib/supabase/admin';
 import { CreateAccountForm } from '@/components/forms/create-account-form';
 import { ResetPasswordButton } from '@/components/forms/reset-password-button';
+import { AccountActions } from '@/components/forms/account-actions';
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import {
@@ -116,7 +117,15 @@ export default async function AccountsPage({ params }: Props) {
                       </div>
                     </TableCell>
                     <TableCell className="text-right">
-                      <ResetPasswordButton userId={r.id} name={r.full_name || r.email} />
+                      <div className="flex flex-wrap items-center justify-end gap-1.5">
+                        <ResetPasswordButton userId={r.id} name={r.full_name || r.email} />
+                        <AccountActions
+                          userId={r.id}
+                          name={r.full_name || r.email}
+                          isActive={r.is_active}
+                          isSelf={r.id === profile.id}
+                        />
+                      </div>
                     </TableCell>
                   </TableRow>
                 ))}

--- a/src/app/[locale]/(dashboard)/dashboard/page.tsx
+++ b/src/app/[locale]/(dashboard)/dashboard/page.tsx
@@ -15,7 +15,7 @@ import { listStock } from '@/actions/stock';
 import { DashboardChart } from '@/components/dashboard/dashboard-chart';
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { formatDateTime, formatMoney, toDateInputValue } from '@/lib/format';
+import { formatDateTime, formatMoney, startOfMonth, endOfMonth } from '@/lib/format';
 import { cn } from '@/lib/utils';
 import type { UserRole } from '@/types/database.types';
 
@@ -40,7 +40,6 @@ export default async function DashboardHome({ params }: Props) {
   setRequestLocale(locale);
 
   const today = new Date();
-  const monthStart = new Date(today.getFullYear(), today.getMonth(), 1);
 
   // Cached from the layout's call -- effectively free here.
   const profile = await getProfile();
@@ -49,7 +48,8 @@ export default async function DashboardHome({ params }: Props) {
 
   const [t, summary, chart, recent, stock, users] = await Promise.all([
     getTranslations('Dashboard'),
-    getSalesSummary(toDateInputValue(monthStart), toDateInputValue(today)),
+    // The month tile covers the whole current month, first day to last day.
+    getSalesSummary(startOfMonth(today), endOfMonth(today)),
     getDashboardChart('monthly', 'sales'),
     listRecentSales(6),
     listStock(),

--- a/src/app/[locale]/(dashboard)/reports/page.tsx
+++ b/src/app/[locale]/(dashboard)/reports/page.tsx
@@ -5,7 +5,7 @@ import { ReconExportButton } from '@/components/reports/recon-export-button';
 import { ReportControls } from '@/components/reports/report-controls';
 import { ReportView } from '@/components/reports/report-view';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { SCHOOL, toDateInputValue } from '@/lib/format';
+import { SCHOOL, toDateInputValue, startOfMonth, endOfMonth } from '@/lib/format';
 import { isReportKey, type ReportKey } from '@/lib/report-types';
 
 type Props = {
@@ -35,17 +35,17 @@ export default async function ReportsPage({ params, searchParams }: Props) {
     await searchParams;
   const now = new Date();
   const today = toDateInputValue(now);
-  const monthStart = toDateInputValue(new Date(now.getFullYear(), now.getMonth(), 1));
 
   // The daily reconciliation defaults to today. Reject non-dates before new Date().
   const from = rawFrom && DATE_RE.test(rawFrom) ? rawFrom : today;
   const to = rawTo && DATE_RE.test(rawTo) ? rawTo : today;
 
-  // The report suite has its own range (defaults to month-to-date) and selected
-  // report, so it never fights the reconciliation's date filter.
+  // The report suite has its own range and selected report, so it never fights
+  // the reconciliation's date filter. It defaults to the whole current month --
+  // the first day to the last day (A-FR: a month is a full calendar month).
   const reportKey: ReportKey = rawReport && isReportKey(rawReport) ? rawReport : 'sales-by-period';
-  const sfrom = rawSfrom && DATE_RE.test(rawSfrom) ? rawSfrom : monthStart;
-  const sto = rawSto && DATE_RE.test(rawSto) ? rawSto : today;
+  const sfrom = rawSfrom && DATE_RE.test(rawSfrom) ? rawSfrom : startOfMonth(now);
+  const sto = rawSto && DATE_RE.test(rawSto) ? rawSto : endOfMonth(now);
 
   const [recon, reportResult, stamp, reconStamp, t] = await Promise.all([
     getDailyReconciliation(from, to),

--- a/src/components/forms/account-actions.tsx
+++ b/src/components/forms/account-actions.tsx
@@ -1,0 +1,132 @@
+'use client';
+
+import { useState, useTransition } from 'react';
+import { PowerIcon, PowerOffIcon, Trash2Icon } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+import { toast } from 'sonner';
+import { useRouter } from '@/i18n/navigation';
+import { setAccountActive, deleteAccount } from '@/actions/accounts';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from '@/components/ui/dialog';
+import { Spinner } from '@/components/ui/spinner';
+
+/**
+ * Super-Admin account controls: (de)activate and delete (A-FR-P4).
+ *
+ * A row for the Super Admin's own account shows neither -- deactivating or
+ * deleting yourself is a lock-out the UI should never offer, and the server
+ * refuses it regardless.
+ */
+export function AccountActions({
+  userId,
+  name,
+  isActive,
+  isSelf
+}: {
+  userId: string;
+  name: string;
+  isActive: boolean;
+  isSelf: boolean;
+}) {
+  const t = useTranslations('Accounts');
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const [confirmOpen, setConfirmOpen] = useState(false);
+
+  if (isSelf) return null;
+
+  function toggleActive() {
+    startTransition(async () => {
+      const res = await setAccountActive(userId, !isActive);
+      if (res.ok) {
+        toast.success(isActive ? t('deactivatedToast', { name }) : t('activatedToast', { name }));
+        router.refresh();
+      } else {
+        toast.error(accountError(res.error, t));
+      }
+    });
+  }
+
+  function confirmDelete() {
+    startTransition(async () => {
+      const res = await deleteAccount(userId);
+      if (res.ok) {
+        toast.success(t('deletedToast', { name }));
+        setConfirmOpen(false);
+        router.refresh();
+      } else {
+        toast.error(accountError(res.error, t));
+      }
+    });
+  }
+
+  return (
+    <div className="inline-flex items-center gap-1.5">
+      <Button variant="outline" size="sm" className="gap-1.5" onClick={toggleActive} disabled={isPending}>
+        {isPending ? (
+          <Spinner className="size-4" />
+        ) : isActive ? (
+          <PowerOffIcon className="size-4" />
+        ) : (
+          <PowerIcon className="size-4" />
+        )}
+        {isActive ? t('deactivate') : t('activate')}
+      </Button>
+
+      <Button
+        variant="ghost"
+        size="sm"
+        className="gap-1.5 text-destructive hover:text-destructive"
+        onClick={() => setConfirmOpen(true)}
+        disabled={isPending}
+      >
+        <Trash2Icon className="size-4" />
+        {t('delete')}
+      </Button>
+
+      <Dialog open={confirmOpen} onOpenChange={setConfirmOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{t('deleteConfirmTitle')}</DialogTitle>
+            <DialogDescription>{t('deleteConfirmBody', { name })}</DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setConfirmOpen(false)} disabled={isPending}>
+              {t('cancel')}
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={confirmDelete}
+              disabled={isPending}
+              className="gap-1.5"
+            >
+              {isPending ? <Spinner className="size-4" /> : <Trash2Icon className="size-4" />}
+              {t('delete')}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}
+
+function accountError(code: string, t: ReturnType<typeof useTranslations<'Accounts'>>) {
+  switch (code) {
+    case 'cannotSelf':
+      return t('cannotSelf');
+    case 'hasActivity':
+      return t('hasActivity');
+    case 'forbidden':
+    case 'unauthorized':
+      return t(code);
+    default:
+      return t('actionFailed');
+  }
+}

--- a/src/components/forms/login-form.tsx
+++ b/src/components/forms/login-form.tsx
@@ -62,7 +62,9 @@ export function LoginForm({ redirectTo }: { redirectTo: string | null }) {
         ? t('invalidCredentials')
         : state.error === 'tooManyAttempts'
           ? t('tooManyAttempts')
-          : t('unexpectedError');
+          : state.error === 'accountInactive'
+            ? t('accountInactive')
+            : t('unexpectedError');
     toast.error(message);
   }, [state, t]);
 

--- a/src/lib/audit.ts
+++ b/src/lib/audit.ts
@@ -162,6 +162,9 @@ export const AUDIT_ACTIONS = [
   'stock_movement',
   'account_created',
   'account_password_reset',
+  'account_activated',
+  'account_deactivated',
+  'account_deleted',
   'profile_updated',
   'password_changed'
 ] as const;

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -46,8 +46,31 @@ export function formatDateTime(value: string | Date, locale: string = 'en'): str
 }
 
 /** `YYYY-MM-DD`, for date inputs and file names. */
+/**
+ * A date as YYYY-MM-DD in LOCAL time. Deliberately not `toISOString().slice(0,10)`:
+ * that converts to UTC first, so in a timezone ahead of UTC (the school is at
+ * UTC+1) local midnight on the 1st becomes 23:00 on the previous day and the
+ * date comes out a day early -- which made "this month" start on the last day of
+ * the previous month.
+ */
 export function toDateInputValue(value: Date): string {
-  return value.toISOString().slice(0, 10);
+  const y = value.getFullYear();
+  const m = String(value.getMonth() + 1).padStart(2, '0');
+  const d = String(value.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}
+
+/** First day of the month containing `value`, as YYYY-MM-DD (local). */
+export function startOfMonth(value: Date): string {
+  return toDateInputValue(new Date(value.getFullYear(), value.getMonth(), 1));
+}
+
+/**
+ * Last day of the month containing `value`, as YYYY-MM-DD (local). Day 0 of the
+ * next month is the last day of this one, so this is correct for 28/29/30/31.
+ */
+export function endOfMonth(value: Date): string {
+  return toDateInputValue(new Date(value.getFullYear(), value.getMonth() + 1, 0));
 }
 
 export const SCHOOL = {

--- a/supabase/policies/08_orders.sql
+++ b/supabase/policies/08_orders.sql
@@ -1,25 +1,28 @@
 -- Orders and their line items.
 --
--- Mirrors the sales policies exactly (03_sales.sql): a seller sees and creates
--- only their own orders, oversight roles see everything, only operators may
--- place one, and nothing is deletable. An order carries money taken at the
--- counter, so it is as much a ledger row as a sale is.
+-- Read is universal, matching sales (03_sales.sql): the open-jobs list is the
+-- Seller's landing screen and must show EVERY order, and Administration sees the
+-- same list read-only (A-FR-9.16, A-FR-9.22). Orders were previously scoped to
+-- their own seller, which hid any order recorded by another account from the
+-- Seller -- the whole team works one shared ledger, exactly as it does for sales.
+--
+-- Write stays gated by role: only operators (seller, maintenance, super_admin)
+-- place an order or move a line along; only the super_admin amends the order row;
+-- nothing is deletable.
 --
 -- Idempotent -- safe to re-run after edits.
 
 -- ---------------------------------------------------------------- orders
 
+-- Superseded by orders_select_all: drop the old per-owner / oversight split.
 drop policy if exists "orders_select_own" on public.orders;
-create policy "orders_select_own"
-  on public.orders for select
-  to authenticated
-  using (seller_id = (select auth.uid()));
-
 drop policy if exists "orders_select_admin" on public.orders;
-create policy "orders_select_admin"
+
+drop policy if exists "orders_select_all" on public.orders;
+create policy "orders_select_all"
   on public.orders for select
   to authenticated
-  using (public.can_oversee());
+  using (true);
 
 drop policy if exists "orders_insert_own" on public.orders;
 create policy "orders_insert_own"
@@ -39,6 +42,8 @@ create policy "orders_update_admin"
 
 -- ---------------------------------------------------------------- order_items
 
+-- Lines inherit the order's visibility. Orders are readable by every signed-in
+-- user now, so their lines are too.
 drop policy if exists "order_items_select_via_order" on public.order_items;
 create policy "order_items_select_via_order"
   on public.order_items for select
@@ -47,7 +52,6 @@ create policy "order_items_select_via_order"
     exists (
       select 1 from public.orders o
       where o.id = order_items.order_id
-        and (o.seller_id = (select auth.uid()) or public.can_oversee())
     )
   );
 
@@ -64,31 +68,18 @@ create policy "order_items_insert_via_order"
     )
   );
 
--- Operators move their own order lines through the workflow. This grants UPDATE
--- on the whole row, which RLS cannot narrow to a single column -- the
--- guard_order_item_contents() trigger is what stops a seller rewriting the
--- price after the parent has paid, and enforce_order_line_transition() is what
--- stops an illegal jump. Together they make this policy safe.
+-- Any operator moves any order line through the workflow -- it is one shared
+-- shop, and the open-jobs card advances a job in one tap regardless of who first
+-- recorded it (A-FR-9.20). This grants UPDATE on the whole row, which RLS cannot
+-- narrow to a column -- guard_order_item_contents() stops a price rewrite and
+-- enforce_order_line_transition() stops an illegal jump, which is what keeps it
+-- safe.
 drop policy if exists "order_items_update_own" on public.order_items;
 create policy "order_items_update_own"
   on public.order_items for update
   to authenticated
-  using (
-    public.can_operate()
-    and exists (
-      select 1 from public.orders o
-      where o.id = order_items.order_id
-        and (o.seller_id = (select auth.uid()) or public.can_oversee())
-    )
-  )
-  with check (
-    public.can_operate()
-    and exists (
-      select 1 from public.orders o
-      where o.id = order_items.order_id
-        and (o.seller_id = (select auth.uid()) or public.can_oversee())
-    )
-  );
+  using (public.can_operate())
+  with check (public.can_operate());
 
 drop policy if exists "order_items_update_admin" on public.order_items;
 create policy "order_items_update_admin"

--- a/supabase/policies/09_collections.sql
+++ b/supabase/policies/09_collections.sql
@@ -5,8 +5,9 @@
 -- tables and must not be able to half-happen. Granting insert as well would
 -- offer a second, unsafe route to the same thing.
 --
--- Visibility follows the order, exactly as order_items do: a seller sees slips
--- against their own orders, oversight roles see all.
+-- Visibility follows the order, exactly as order_items do: orders are readable
+-- by every signed-in user (08_orders.sql), so the slips against them are too --
+-- the collection history is shared like the sales ledger.
 --
 -- Idempotent -- safe to re-run after edits.
 
@@ -17,10 +18,11 @@ create policy "collections_select_via_order"
   on public.collections for select
   to authenticated
   using (
+    -- Orders are readable by every signed-in user (08_orders.sql), so the slips
+    -- against them are too -- the collection history is shared like the ledger.
     exists (
       select 1 from public.orders o
       where o.id = collections.order_id
-        and (o.seller_id = (select auth.uid()) or public.can_oversee())
     )
   );
 
@@ -32,10 +34,7 @@ create policy "collection_items_select_via_collection"
   to authenticated
   using (
     exists (
-      select 1
-      from public.collections c
-      join public.orders o on o.id = c.order_id
+      select 1 from public.collections c
       where c.id = collection_items.collection_id
-        and (o.seller_id = (select auth.uid()) or public.can_oversee())
     )
   );


### PR DESCRIPTION
## Summary

Four fixes/improvements reported against the running app, plus restoration of message keys lost in a rollback of `messages/*.json`.

## 1. Month ranges = full calendar month
`toDateInputValue` formatted via `toISOString()` (UTC), so at UTC+1 the 1st of the month rendered as the previous day — "this month" started on the last day of the previous month. Now formats in **local** time, with new `startOfMonth`/`endOfMonth` helpers (day 0 of next month → correct 28/29/30/31). The reports suite and the dashboard month tiles span the first→last day of the month.

## 2. Seller could not see new orders
Orders were owner-scoped for reads while sales are shared-read, so the Seller only saw orders they personally recorded — against A-FR-9.16/9.22 (the open-jobs list shows *every* order to the Seller, and Administration sees the same list). Made `orders`, `order_items`, `collections`, `collection_items` **shared-read** like sales, and let any operator advance an order line (one-tap status, A-FR-9.20). Policy files only — no schema change.

## 3. Support message reaches the Super Admin
The dashboard "Report a problem" dialog already stored the user's text for admins to read; it now also **notifies** the Super Admin and Maintenance (bell notification linking to the reports list).

## 4. Account activate / deactivate / delete (A-FR-P4)
- `setAccountActive` and `deleteAccount` server actions — Super-Admin-only, audited, cannot act on your own account; deleting an account that has activity on record is refused (FK-protected) so it must be deactivated instead (name stays on its records, P-4).
- **Login now blocks deactivated accounts** — previously unenforced: credentials still verify (no account enumeration) but the session is dropped and login refused.
- `AccountActions` UI on the Accounts screen (activate/deactivate + confirmed delete).
- Audit labels for `account_activated` / `account_deactivated` / `account_deleted`.

## Restored messages (rollback recovery)
Scanned the codebase for every translation key vs. the current `en.json`/`fr.json` and re-added what the rollback removed: `Accounts.*` (the new controls), `Notifications.types.bug_reported`, `Login.accountInactive`, and the `Audit.actions.account_*` labels — both locales, parity verified.

## Files
- `src/lib/format.ts` (local dates + month helpers), reports/dashboard pages
- `supabase/policies/08_orders.sql`, `09_collections.sql` (shared read; corrected header comment)
- `src/actions/bug-reports.ts` (notify), `src/actions/accounts.ts` + `auth.ts` (account actions + login guard)
- `src/components/forms/account-actions.tsx` (new), accounts page wiring, `login-form.tsx`
- `src/lib/audit.ts` (new action labels), `messages/en.json` + `fr.json`

## Verification
- `tsc --noEmit` clean, `eslint .` clean, EN/FR key parity exact, key-usage scan reports no missing keys.
- **Not run:** the DB isn't exercised here. Task 2 is in RLS policy files, so run `npm run db:policies` against the database for it to take effect.
