### PR TITLE
PR/feat(sales): show stock per chosen size, not on the product dropdown

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -415,6 +415,8 @@
     "size": "Size",
     "unitPrice": "Unit price",
     "availableShort": "{count} available",
+    "sizeInStock": "{count} in stock (size {size})",
+    "sizeOutOfStock": "Size {size}: out of stock",
     "quantity": "Qty",
     "lineTotal": "Total",
     "subtotal": "Subtotal",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -415,6 +415,8 @@
     "size": "Taille",
     "unitPrice": "Prix unitaire",
     "availableShort": "{count} disponible(s)",
+    "sizeInStock": "{count} en stock (taille {size})",
+    "sizeOutOfStock": "Taille {size} : rupture de stock",
     "quantity": "Qt\u00e9",
     "lineTotal": "Total",
     "subtotal": "Sous-total",

--- a/src/actions/stock.ts
+++ b/src/actions/stock.ts
@@ -230,20 +230,22 @@ export async function listProducts() {
     reservedByProductSize()
   ]);
 
-  // One option per product (size is picked on the line). The availability shown
-  // here is the total across sizes -- a rough at-a-glance figure; the real
-  // per-size check happens at sale time against the chosen size.
+  // One option per product; the count is NOT shown against the product itself.
+  // Stock is per size, so `stockBySize` carries the available quantity for each
+  // size (in stock minus what Ready orders reserve). The sale line reads it only
+  // once a size is picked -- picking "Shirt" shows nothing, picking size 20
+  // shows that size's count (50, or 0 for out of stock).
   return (data ?? []).map((product) => {
     const levels = Array.isArray(product.levels)
       ? product.levels
       : product.levels
         ? [product.levels]
         : [];
-    const inStock = levels.reduce((sum, l) => sum + (l.quantity ?? 0), 0);
-    const reservedQty = levels.reduce(
-      (sum, l) => sum + (reserved[levelKey(product.id, l.size ?? '')] ?? 0),
-      0
-    );
+    const stockBySize: Record<string, number> = {};
+    for (const l of levels) {
+      const size = l.size ?? '';
+      stockBySize[size] = (l.quantity ?? 0) - (reserved[levelKey(product.id, size)] ?? 0);
+    }
     return {
       id: product.id,
       sku: product.sku,
@@ -251,9 +253,7 @@ export async function listProducts() {
       name_fr: product.name_fr,
       unit_price: product.unit_price,
       category: product.category,
-      inStock,
-      reserved: reservedQty,
-      available: inStock - reservedQty
+      stockBySize
     };
   });
 }

--- a/src/components/forms/return-form.tsx
+++ b/src/components/forms/return-form.tsx
@@ -53,7 +53,6 @@ type Product = {
   name_en: string;
   name_fr: string | null;
   unit_price: number;
-  available: number;
 };
 
 type OutgoingLine = { productId: string; size: string | null; quantity: number };

--- a/src/components/forms/sale-form.tsx
+++ b/src/components/forms/sale-form.tsx
@@ -54,13 +54,12 @@ export type ProductOption = {
   unit_price: number;
   category: string;
   /**
-   * What can actually be sold: in stock minus what Ready orders have already
-   * claimed (A-FR-9.10). Optional so the production form, which cares about
-   * neither, can keep passing the same shape.
+   * Available quantity per size (in stock minus what Ready orders reserve,
+   * A-FR-9.10). Keyed by size label. The count is shown only after a size is
+   * picked, never against the product itself. Optional so the production form,
+   * which doesn't need it, can pass the same shape.
    */
-  available?: number;
-  inStock?: number;
-  reserved?: number;
+  stockBySize?: Record<string, number>;
 };
 
 const DEFAULTS: SaleInput = {
@@ -440,6 +439,11 @@ export function SaleForm({
             const line =
               (Number(watchedItems?.[index]?.unitPrice) || 0) *
               (Number(watchedItems?.[index]?.quantity) || 0);
+            // Per-size availability, shown only once a size is chosen. A custom
+            // size that isn't a tracked bucket reads as 0 in stock.
+            const chosenSize = watchedItems?.[index]?.size ?? null;
+            const sizeStock =
+              chosen && chosenSize ? chosen.stockBySize?.[chosenSize] ?? 0 : null;
 
             return (
               <div
@@ -455,25 +459,12 @@ export function SaleForm({
                       <SelectValue placeholder={t('selectProduct')} />
                     </SelectTrigger>
                     <SelectContent>
+                      {/* No stock number here: stock is per size, so the count
+                          is meaningless against the garment alone. It appears
+                          under the size bar once a size is picked. */}
                       {products.map((product) => (
                         <SelectItem key={product.id} value={product.id}>
-                          <span className="flex w-full items-center justify-between gap-3">
-                            <span>{productLabel(product)}</span>
-                            {/* Availability sits beside the name so the seller
-                                reads it while choosing rather than discovering
-                                it afterwards. */}
-                            {typeof product.available === 'number' ? (
-                              <span
-                                className={
-                                  product.available <= 0
-                                    ? 'text-xs font-medium text-destructive'
-                                    : 'text-xs text-muted-foreground'
-                                }
-                              >
-                                {t('availableShort', { count: product.available })}
-                              </span>
-                            ) : null}
-                          </span>
+                          {productLabel(product)}
                         </SelectItem>
                       ))}
                     </SelectContent>
@@ -515,21 +506,6 @@ export function SaleForm({
                     inputMode="numeric"
                     aria-invalid={Boolean(itemErrors?.quantity)}
                   />
-                  {/* Shown, never enforced: selling below stock is allowed with
-                      a warning, an override and an audit row, which is a
-                      separate issue. A hard cap here would have to be undone
-                      there. */}
-                  {chosen && typeof chosen.available === 'number' ? (
-                    <p
-                      className={
-                        wanted > chosen.available
-                          ? 'mt-1 text-xs font-medium text-amber-600 dark:text-amber-500'
-                          : 'mt-1 text-xs text-muted-foreground'
-                      }
-                    >
-                      {t('availableShort', { count: chosen.available })}
-                    </p>
-                  ) : null}
                 </div>
 
                 <div className="flex items-end justify-between gap-2 sm:col-span-3">
@@ -556,14 +532,31 @@ export function SaleForm({
                 {/* Size bar, once a product is picked (A-FR-4.2). Sits on its
                     own full-width row so the boxes have room on a phone. */}
                 {chosen && sizes.length > 0 ? (
-                  <div className="sm:col-span-12">
+                  <div className="sm:col-span-12 space-y-1.5">
                     <SizeBar
                       sizes={sizes}
-                      value={watchedItems?.[index]?.size ?? null}
+                      value={chosenSize}
                       onChange={(next) =>
                         setValue(`items.${index}.size`, next, { shouldDirty: true })
                       }
                     />
+                    {/* Stock for the CHOSEN size only (A-FR-9.10). Zero is shown
+                        plainly; below-stock warns but never blocks the sale. */}
+                    {chosenSize && sizeStock !== null ? (
+                      <p
+                        className={
+                          sizeStock <= 0
+                            ? 'text-xs font-medium text-destructive'
+                            : wanted > sizeStock
+                              ? 'text-xs font-medium text-amber-600 dark:text-amber-500'
+                              : 'text-xs text-muted-foreground'
+                        }
+                      >
+                        {sizeStock <= 0
+                          ? t('sizeOutOfStock', { size: chosenSize })
+                          : t('sizeInStock', { count: sizeStock, size: chosenSize })}
+                      </p>
+                    ) : null}
                   </div>
                 ) : null}
               </div>


### PR DESCRIPTION
## Summary

Stock is tracked per `(product, size)`, but the sale screen was showing a single product-level availability number on the product dropdown — meaningless when the same garment has different counts per size. Now the dropdown shows no number, and the stock count appears only once a **size** is picked, for that size.

## Behaviour

- **Product dropdown:** no stock number — just the garment name.
- **After picking a size**, a line under the size bar shows that size's stock:
  - in stock → "50 in stock (size 20)" (muted; turns **amber** if the entered quantity exceeds it — warns, never blocks, per A-FR-9.10);
  - none → "Size 20: out of stock" (red);
  - a custom size with no tracked bucket reads as 0.

Example: choose *Shirt* → no number; tap *size 20* → "50 in stock (size 20)"; a size with none → "out of stock". This reflects the per-size quantities that production entry records.

## Changes

- `src/actions/stock.ts` — `listProducts` now returns `stockBySize: Record<string, number>` (available per size) instead of product-level `inStock`/`reserved`/`available` totals.
- `src/components/forms/sale-form.tsx` — `ProductOption` carries `stockBySize`; removed the availability display from the product `SelectItem`; compute `sizeStock` for the chosen size and render it under the size bar (out-of-stock / in-stock / over-stock states).
- `src/components/forms/return-form.tsx` — dropped the now-unused `available` field from its local `Product` type (matches the new `listProducts` shape).
- `messages/en.json` / `fr.json` — new `Sales.sizeInStock` and `Sales.sizeOutOfStock` (both locales, parity verified).

## Scope

Applied to the **sale** screen (the flow described). The **order** screen intentionally shows no stock — orders exist for garments not in stock. Say the word to extend the per-size count there too.

## Verification

`tsc --noEmit` clean, `eslint` clean on changed files, EN/FR message parity exact. No schema change (uses the existing `stock_levels (product_id, size)` model). Nothing else touched.
